### PR TITLE
lpddr5: add zqc refresher through MPC ZQC_LATCH commands

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -734,6 +734,12 @@ def get_lpddr5_phy_init_sequence(phy_settings, timing_settings):
         # zero-defaults
     ])
     mr[22] = 0  # Write/read link ECC disabled
+    mr[28] = reg([
+        (0, 1, 0), # ZQ Reset
+        (1, 1, 0), # ZQ Stop
+        (2, 2, 0b01), # ZQ background calibration interval (64ms default)
+        (5, 1, 0), # ZQ mode
+    ])
 
     def cmd_mr(ma):
         # Convert Mode Register Write command to DFI as expected by PHY

--- a/litedram/phy/lpddr5/simsoc.py
+++ b/litedram/phy/lpddr5/simsoc.py
@@ -78,7 +78,7 @@ class LPDDR5ExampleModule(SDRAMModule):
     # TODO: find a way to select if we need masked writes
     tccd = {"write": (8, None), "masked-write": (32, None)}
 
-    technology_timings = _TechnologyTimings(tREFI=32e6/8192, tWTR=(4, 12), tCCD=tccd["masked-write"], tRRD=(2, 5), tZQCS=None)
+    technology_timings = _TechnologyTimings(tREFI=32e6/8192, tWTR=(4, 12), tCCD=tccd["masked-write"], tRRD=(2, 5), tZQCS=(128, 80))
     speedgrade_timings = {
         "default": _SpeedgradeTimings(tRP=(2, 21), tRCD=(2, 18), tWR=(3, 34), tRFC=210, tFAW=20, tRAS=(3, 42)),  # TODO: tRAS_max
     }


### PR DESCRIPTION
This PR adds the capability to commit the periodic background ZQ calibrations through the ZQC_LATCH command. Furthermore it is based on top of https://github.com/antmicro/litedram/tree/jboc/lpddr5-rebase

Notes:

- The LiteDRAM refresher does not update the dfi addresses, therefore I have added fake commands as a workaround based on the `SpecialCmd` bank value. 
- The ZQC refresher won't work on simulation as it is set to be running at a 1Hz frequency. This means that ZQC will be enabled every second, unfeasible for simulation. To verify the ZQC in simulation, this would need to be set to something higer, e.g. `1e8`: https://github.com/antmicro/litedram/blob/e3c2ab075785c5a979268e573f5bb5b94582b1c4/litedram/core/controller.py#L36