### PR TITLE
Change phytype of DoubleRateDDR5SimPHY

### DIFF
--- a/litedram/phy/ddr5/simphy.py
+++ b/litedram/phy/ddr5/simphy.py
@@ -105,7 +105,7 @@ class DoubleRateDDR5SimPHY(SimSerDesMixin, DoubleRateDDR5PHY):
         super().__init__(pads,
             ser_latency  = Latency(sys2x=Serializer.LATENCY),
             des_latency  = Latency(sys2x=Deserializer.LATENCY),
-            phytype      = "DDR5SimPHY",
+            phytype      = "DoubleRateDDR5SimPHY",
             **kwargs)
         self.submodules.half_delay = ClockDomainsRenamer("sys2x")(Module())
 


### PR DESCRIPTION
It is non-functional change. Now it will be easier to check if the logs are from single rate phy simulation or double.