### PR TITLE
Fix nbanks in MT60B2G8HB48B class

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1167,7 +1167,7 @@ class MT53E256M16D1(SDRAMModule):
 class MT60B2G8HB48B(SDRAMModule):
     memtype = "DDR5"
 
-    nbanks = 16
+    nbanks = 32
     nrows = 65536
     ncols = 1024
 


### PR DESCRIPTION
I changed `nbanks` to 32 according to https://media-www.micron.com/-/media/client/global/documents/products/data-sheet/dram/ddr5/16gb_ddr5_sdram_diereva.pdf?rev=c95e4a49184145f18e105cc41e0ee643 (page 2).