### PR TITLE
Improve memory model to force proper timing

### DIFF
--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -438,7 +438,7 @@ class DataSim(Module, AutoCSR):
 
         bl = 16
 
-        dq_dqs_ratio = len(pads.dq) // len(pads.dqs)
+        dq_dqs_ratio = len(pads.dq) // len(pads.dqs_t)
         if dq_dqs_ratio == 8:
             module = modules.MT60B2G8HB48B
         elif dq_dqs_ratio == 4:
@@ -461,10 +461,10 @@ class DataSim(Module, AutoCSR):
             log_level=log_level, clk_freq=clk_freq)
         dqs_kwargs = dict(bl=bl, log_level=log_level, clk_freq=clk_freq)
 
-        self.submodules.dq_wr = ClockDomainsRenamer(cd_dq_wr)(DQWrite(dq=pads.dq, dmi=pads.dmi, ports=ports, **dq_kwargs))
+        self.submodules.dq_wr = ClockDomainsRenamer(cd_dq_wr)(DQWrite(dq=pads.dq, dmi=pads.dm_n, ports=ports, **dq_kwargs))
         self.submodules.dq_rd = ClockDomainsRenamer(cd_dq_rd)(DQRead(dq=pads.dq_i, ports=ports, **dq_kwargs))
-        self.submodules.dqs_wr = ClockDomainsRenamer(cd_dqs_wr)(DQSWrite(dqs=pads.dqs, **dqs_kwargs))
-        self.submodules.dqs_rd = ClockDomainsRenamer(cd_dqs_rd)(DQSRead(dqs=pads.dqs_i,**dqs_kwargs))
+        self.submodules.dqs_wr = ClockDomainsRenamer(cd_dqs_wr)(DQSWrite(dqs=pads.dqs_t, **dqs_kwargs))
+        self.submodules.dqs_rd = ClockDomainsRenamer(cd_dqs_rd)(DQSRead(dqs=pads.dqs_t_i,**dqs_kwargs))
 
         write = Signal()
         read = Signal()

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -18,7 +18,7 @@ from litedram.common import TappedDelayLine
 from litedram.phy.utils import delayed, edge
 from litedram.phy.sim_utils import SimLogger, PulseTiming, log_level_getter
 from litedram.phy.ddr5.commands import MPC
-from litedram.modules import MT60B2G8HB48B
+from litedram import modules
 
 
 class DDR5Sim(Module, AutoCSR):
@@ -438,10 +438,16 @@ class DataSim(Module, AutoCSR):
 
         bl = 16
 
-        nbanks = MT60B2G8HB48B.nbanks
+        dq_dqs_ratio = len(pads.dq) // len(pads.dqs)
+        if dq_dqs_ratio == 8:
+            module = modules.MT60B2G8HB48B
+        elif dq_dqs_ratio == 4:
+            module = modules.M329R8GA0BB0
+
+        nbanks = module.nbanks
         # Per-bank memory
-        nrows = MT60B2G8HB48B.nrows
-        ncols = MT60B2G8HB48B.ncols
+        nrows = module.nrows
+        ncols = module.ncols
         mems = [Memory(len(pads.dq), depth=nrows * ncols) for _ in range(nbanks)]
         ports = [mem.get_port(write_capable=True, we_granularity=8, async_read=True) for mem in mems]
         self.specials += mems + ports

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -212,11 +212,16 @@ class CommandsSim(Module, AutoCSR):
         self.submodules.fsm = fsm = ResetInserter()(FSM())
         self.comb += [
             If(self.tpw_reset.ready_p,
-                self.tinit3.trigger.eq(pads.reset_n),
                 fsm.reset.eq(1),
                 self.log.info("FSM reset")
             )
         ]
+        fsm.act("Reset",
+            If(pads.reset_n,
+                self.tinit3.trigger.eq(pads.reset_n),
+                NextState("Initialization"),
+            )
+        )
         fsm.act("Initialization",
             If(~delayed(self, pads.cs_n) & pads.cs_n,
                 self.log.info("CS released"),

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import math
-from operator import or_
+from operator import or_, and_
 from functools import reduce
 from collections import defaultdict, OrderedDict
 
@@ -49,15 +49,13 @@ class DDR5Sim(Module, AutoCSR):
         DDR5 read latency (RL).
     cwl : int
         DDR5 write latency (WL).
-    disable_delay : bool
-        Disable checking of timings that rely on long CPU delays (mostly init sequence
-        timings). This is useful when running LiteX BIOS with CONFIG_DISABLE_DELAYS on.
     log_level : str
         SimLogger initial logging level (formatted for parsing with `log_level_getter`).
     """
-    def __init__(self, pads, *, sys_clk_freq, cl, cwl, disable_delay, log_level, geom_settings):
+    def __init__(self, pads, *, sys_clk_freq, cl, cwl, log_level, geom_settings):
         log_level = log_level_getter(log_level)
 
+        bl_max    = 16 # We only support BL8 and BL16, there is no support for BL32
         cd_cmd    = "sys4x_90"
         cd_dq_wr  = "sys4x_90_ddr"
         cd_dqs_wr = "sys4x_ddr"
@@ -65,15 +63,22 @@ class DDR5Sim(Module, AutoCSR):
         cd_dqs_rd = "sys4x_ddr"
 
         self.submodules.data_cdc = ClockDomainCrossing(
-            [("we", 1), ("masked", 1), ("bank", geom_settings.bankbits), ("row", 18), ("col", 11)],
-            cd_from=cd_cmd, cd_to=cd_dq_wr)
+            [("we", 1),
+             ("masked", 1),
+             ("bank", geom_settings.bankbits),
+             ("row", geom_settings.rowbits),
+             ("col", geom_settings.colbits),
+             ("bl_width", bl_max.bit_length()),
+            ],
+            cd_from=cd_cmd,
+            cd_to=cd_dq_wr)
 
         cmd = CommandsSim(pads,
             data_cdc      = self.data_cdc,
             clk_freq      = 4*sys_clk_freq,
             log_level     = log_level("cmd"),
             geom_settings = geom_settings,
-            init_delays   = not disable_delay,
+            bl_max        = bl_max,
         )
         self.submodules.cmd = ClockDomainsRenamer(cd_cmd)(cmd)
 
@@ -86,6 +91,7 @@ class DDR5Sim(Module, AutoCSR):
             cl        = cl,
             cwl       = cwl,
             log_level = log_level("data"),
+            bl_max        = bl_max,
         )
         self.submodules.data = ClockDomainsRenamer(cd_dq_wr)(data)
 
@@ -101,16 +107,17 @@ class CommandsSim(Module, AutoCSR):
 
     Command simulator should work in the clock domain of `pads.clk_p` (SDR).
     """
-    def __init__(self, pads, data_cdc, *, clk_freq, log_level, geom_settings, init_delays=False):
+    def __init__(self, pads, data_cdc, *, clk_freq, log_level, geom_settings, bl_max):
         self.submodules.log = log = SimLogger(log_level=log_level, clk_freq=clk_freq)
         self.log.add_csrs()
 
         # Mode Registers storage
-        self.mode_regs = Array([Signal(8) for _ in range(256)])
+        self.mode_regs = Array([Signal(8) if i != 8 else Signal(8, reset=8) for i in range(256)])
         # Active banks
         self.number_of_banks = 2 ** geom_settings.bankbits;
         self.active_banks = Array([Signal() for _ in range(self.number_of_banks)])
-        self.active_rows = Array([Signal(18) for _ in range(self.number_of_banks)])
+        self.active_rows = Array([Signal(geom_settings.rowbits) for _ in range(self.number_of_banks)])
+
         # Connection to DataSim
         self.data_en = TappedDelayLine(ntaps=26)
         self.data = data_cdc
@@ -123,56 +130,76 @@ class CommandsSim(Module, AutoCSR):
 
         self.cs_n_low   = Signal(14)
         self.cs_n_high  = Signal(14)
-        self.handle_cmd = Signal()
+        self.handle_1_tick_cmd  = Signal()
+        self.handle_2_tick_cmd  = Signal()
+        self.handled_1_tick_cmd = Signal()
         self.mpc_op     = Signal(8)
+        self.bl_max     = bl_max
 
         cmds_enabled = Signal()
         cmd_handlers = OrderedDict(
-            MRW = self.mrw_handler(),
-            REF = self.refresh_handler(),
-            ACT = self.activate_handler(),
-            PRE = self.precharge_handler(),
-            RD  = self.read_handler(),
-            MPC = self.mpc_handler(),
-            WR  = self.write_handler(),
+            MRW  = self.mrw_handler(),
+            REF  = self.refresh_handler(),
+            ACT  = self.activate_handler(),
+            PRE  = self.precharge_handler(),
+            RD   = self.read_handler(),
+            MPC  = self.mpc_handler(),
+            WR   = self.write_handler(),
+            NOP  = self.nop_handler(),
         )
 
         self.comb += [
             If(cmds_enabled,
-                If(Cat(cs_n.taps) == 0b01,
-                    self.handle_cmd.eq(1),
+                If(Cat(cs_n.taps) == 0b00,
+                    self.handle_1_tick_cmd.eq(1),
+                    self.cs_n_low.eq(ca.taps[1]),
+                ).Elif(Cat(cs_n.taps) == 0b01,
+                    self.handle_2_tick_cmd.eq(1),
                     self.cs_n_low.eq(ca.taps[1]),
                     self.cs_n_high.eq(ca.taps[0]),
                 )
             ),
-            If(self.handle_cmd & ~reduce(or_, cmd_handlers.values()),
+            If(self.handle_2_tick_cmd & ~reduce(or_, cmd_handlers.values()),
                 self.log.error("Unexpected command: cs_n_low=0b%14b cs_n_high=0b%14b", self.cs_n_low, self.cs_n_high)
             ),
+            If(self.handle_1_tick_cmd & ~reduce(or_, cmd_handlers.values()),
+                self.log.error("Unexpected command: cs_n_low=0b%14b", self.cs_n_low)
+            ),
         ]
+        self.sync += [If(self.handle_1_tick_cmd,
+                        If(reduce(or_, cmd_handlers.values()),
+                            self.handled_1_tick_cmd.eq(1)
+                        ).Else(
+                            self.handled_1_tick_cmd.eq(0)
+                        ))]
 
-        def ck(t):
-            return math.ceil(t * clk_freq)
+        def ck(t, freq):
+            return math.ceil(t * freq)
 
-        self.submodules.tinit0 = PulseTiming(ck(20e-3))  # makes no sense in simulation
-        self.submodules.tinit1 = PulseTiming(ck(200e-6))
-        self.submodules.tinit2 = PulseTiming(ck(10e-9))
-        self.submodules.tinit3 = PulseTiming(ck(2e-3))
-        self.submodules.tinit4 = PulseTiming(5)  # TODO: would require counting pads.clk_p ticks
-        self.submodules.tinit5 = PulseTiming(ck(2e-6))
-        self.submodules.tzqcal = PulseTiming(ck(1e-6))
-        self.submodules.tzqlat = PulseTiming(max(8, ck(30e-9)))
-        self.submodules.tpw_reset = PulseTiming(ck(100e-9))
+        # We check "Reset Initialization with Stable Power" sequence
+        # Power-up Initialization Sequence is cloase to imposible to track in simulation
+        self.submodules.tpw_reset = PulseTiming(ck(1e-6, clk_freq))
+        self.submodules.tinit2    = PulseTiming(ck(10e-9, clk_freq))
+        self.submodules.tinit3    = PulseTiming(ck(4e-3, clk_freq))
+        self.submodules.tinit4    = PulseTiming(ck(2e-6, clk_freq))
+        self.submodules.tcksrx    = PulseTiming(max(ck(3.5e-9, clk_freq), 8))
+        self.submodules.tinit5    = PulseTiming(3)
+        self.submodules.xpr       = PulseTiming(ck(410e-9, clk_freq))
+
+        self.submodules.tzqcal = PulseTiming(ck(1e-6, clk_freq))
+        self.submodules.tzqlat = PulseTiming(max(8, ck(30e-9, clk_freq)))
+
 
         self.comb += [
-            self.tinit1.trigger.eq(1),
-            self.tinit3.trigger.eq(pads.reset_n),
             self.tpw_reset.trigger.eq(~pads.reset_n),
+            self.tinit2.trigger.eq(~pads.cs_n),
             If(~delayed(self, pads.reset_n) & pads.reset_n,
                 self.log.info("RESET released"),
-                If(~self.tinit1.ready,
-                    self.log.warn("tINIT1 violated: RESET deasserted too fast")
+                If(~self.tinit2.ready,
+                    self.log.error("tINIT2 violated: RESET deasserted too fast")
                 ),
             ),
+            self.tcksrx.trigger.eq(~delayed(self, pads.ck_t) & pads.ck_t),
             If(delayed(self, pads.reset_n) & ~pads.reset_n,
                 self.log.info("RESET asserted"),
             ),
@@ -181,26 +208,55 @@ class CommandsSim(Module, AutoCSR):
         self.submodules.fsm = fsm = ResetInserter()(FSM())
         self.comb += [
             If(self.tpw_reset.ready_p,
+                self.tinit3.trigger.eq(pads.reset_n),
                 fsm.reset.eq(1),
                 self.log.info("FSM reset")
             )
         ]
-        fsm.act("RESET",
-            If(self.tinit3.ready_p | (not init_delays),
-                NextState("EXIT-PD")  # Td
-            )
+        fsm.act("Initialization",
+            If(~delayed(self, pads.cs_n) & pads.cs_n,
+                self.log.info("CS released"),
+                If(~self.tinit3.ready,
+                    self.log.error("tINIT3 violated: CS_n deasserted too fast"),
+                ).Else(
+                    self.tinit4.trigger.eq(1),
+                    self.log.info("Tinit4 triggered"),
+                    NextState("CMOS_Registration")
+                ),
+            ).Elif(pads.cs_n,
+                self.log.error("tINIT3 violated: CS_n deasserted too fast"),
+            ),
+        )
+        fsm.act("CMOS_Registration",
+            If(delayed(self, pads.cs_n) & ~pads.cs_n,
+                self.log.info("CMOS registration ending"),
+                If(~self.tcksrx.ready,
+                    self.log.error("tCKSRX violated: CS_n asserted too fast"),
+                ).Elif(~self.tinit4.ready,
+                    self.log.error("tINIT4 violated: CS_n asserted too fast"),
+                ).Else(
+                    self.tinit5.trigger.eq(1),
+                    NextState("EXIT-PD")
+                ),
+            ).Elif(~reduce(and_, pads.ca),
+                self.log.error("CMD bus must be held high")
+            ),
         )
         fsm.act("EXIT-PD",
-            self.tinit5.trigger.eq(1),
-            If(self.tinit5.ready_p | (not init_delays),
+            If(pads.ca[:5] != 0b11111 | pads.cs_n,
+                self.log.error("Incorrect exit sequence"),
+            ),
+            If(self.tinit5.ready_p,
+                self.log.info("Reset sequence finished"),
                 NextState("MRW")  # Te
             )
         )
         fsm.act("MRW",
             cmds_enabled.eq(1),
-            If(self.handle_cmd & ~cmd_handlers["MRW"] & ~cmd_handlers["MPC"],
+            If(self.handle_2_tick_cmd & ~cmd_handlers["MRW"] & ~cmd_handlers["MPC"] & ~self.handled_1_tick_cmd,
                 self.log.warn("Only MRW/MRR commands expected before ZQ calibration"),
                 self.log.warn(" ".join("{}=%d".format(cmd) for cmd in cmd_handlers.keys()), *cmd_handlers.values()),
+                self.log.warn("Unexpected command: cs_n_low=0b%14b cs_n_high=0b%14b", self.cs_n_low, self.cs_n_high)
             ),
             If(cmd_handlers["MPC"],
                 If(self.mpc_op != MPC.ZQC_START,
@@ -213,11 +269,11 @@ class CommandsSim(Module, AutoCSR):
         fsm.act("ZQC",
             self.tzqcal.trigger.eq(1),
             cmds_enabled.eq(1),
-            If(self.handle_cmd,
+            If(self.handle_2_tick_cmd,
                 If(~(cmd_handlers["MPC"] & (self.mpc_op == MPC.ZQC_LATCH)),
                     self.log.error("Expected ZQC-LATCH")
                 ).Else(
-                    If(init_delays & ~self.tzqcal.ready,
+                    If(~self.tzqcal.ready,
                         self.log.warn("tZQCAL violated")
                     ),
                     NextState("NORMAL")  # Tg
@@ -227,7 +283,7 @@ class CommandsSim(Module, AutoCSR):
         fsm.act("NORMAL",
             cmds_enabled.eq(1),
             self.tzqlat.trigger.eq(1),
-            If(init_delays & self.handle_cmd & ~self.tzqlat.ready,
+            If(self.handle_2_tick_cmd & ~self.tzqlat.ready,
                 self.log.warn("tZQLAT violated")
             ),
         )
@@ -245,15 +301,15 @@ class CommandsSim(Module, AutoCSR):
             })
         )
 
-    def cmd_one_step(self, name, cond, comb, sync=None):
+    def cmd_one_step(self, name, cond, comb, handle_cmd, sync=None):
         matched = Signal()
-        self.comb += If(self.handle_cmd & cond,
+        self.comb += If(handle_cmd & cond,
             self.log.debug(name),
             matched.eq(1),
             *comb
         )
         if sync is not None:
-            self.sync += If(self.handle_cmd & cond,
+            self.sync += If(handle_cmd & cond,
                 *sync
             )
         return matched
@@ -269,6 +325,18 @@ class CommandsSim(Module, AutoCSR):
                 ma.eq(self.cs_n_low[5:13]),
                 NextValue(self.mode_regs[ma], op),
             ],
+            handle_cmd = self.handle_2_tick_cmd,
+        )
+
+    def nop_handler(self):
+        ma  = Signal(8)
+        op  = Signal(8)
+        return self.cmd_one_step("NOP",
+            cond = self.cs_n_low[:5] == 0b11111,
+            comb = [
+                self.log.info("NOP"),
+            ],
+            handle_cmd = self.handle_1_tick_cmd | self.handle_2_tick_cmd,
         )
 
     def refresh_handler(self):
@@ -285,7 +353,8 @@ class CommandsSim(Module, AutoCSR):
                     self.log.info("REF: bank = %d", bank),
                     bank.eq(self.cs_n_low[6:8]),
                 )
-            ]
+            ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 
     def activate_handler(self):
@@ -305,6 +374,7 @@ class CommandsSim(Module, AutoCSR):
                 self.active_banks[bank].eq(1),
                 self.active_rows[bank].eq(row),
             ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 
     def precharge_handler(self):
@@ -328,7 +398,8 @@ class CommandsSim(Module, AutoCSR):
                         self.log.warn("PRE on inactive bank: bank=%d", bank)
                     ),
                 ),
-            ]
+            ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 
     def mpc_handler(self):
@@ -340,20 +411,31 @@ class CommandsSim(Module, AutoCSR):
                 self.mpc_op.eq(self.cs_n_low[5:13]),
                 Case(self.mpc_op, cases)
             ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 
     def read_handler(self):
-        bank = Signal(5)
-        row  = Signal(18)
-        col  = Signal(11)
+        bank     = Signal(5)
+        row      = Signal(18)
+        col      = Signal(11)
+        bl_width = Signal(self.bl_max.bit_length())
         auto_precharge = Signal()
 
         return self.cmd_one_step("READ",
             cond = self.cs_n_low[:5] == 0b11101,
             comb = [
                 If(~self.cs_n_low[5],
-                   self.log.warn("Command places the DRAM into alternate burst mode; currently unsupported")
-                   ),
+                   Case(self.mode_regs[0][:2], {
+                        0:  bl_width.eq(8),
+                        1:  bl_width.eq(8),
+                        "default": [
+                            self.log.error("Model does not support burst length of 32, setting BL 16", bank, row, col),
+                            bl_width.eq(16),
+                        ],
+                   }),
+                ).Else(
+                    bl_width.eq(16),
+                ),
                 bank.eq(self.cs_n_low[6:11]),
                 row.eq(self.active_rows[bank]),
                 col.eq(Cat(Replicate(0, 2), self.cs_n_high[:9])),
@@ -362,7 +444,8 @@ class CommandsSim(Module, AutoCSR):
 
                 # sanity checks
                 If(~self.active_banks[bank],
-                    self.log.error("READ command on inactive bank: bank=%d row=%d col=%d", bank, row, col)
+                    self.log.error("READ command on inactive bank: bank=%d row=%d col=%d", bank, row, col),
+                    Finish(),
                 ),
                 If(auto_precharge,
                     self.log.info("AUTO-PRECHARGE: bank=%d row=%d", bank, row),
@@ -375,24 +458,37 @@ class CommandsSim(Module, AutoCSR):
                 self.data.sink.bank.eq(bank),
                 self.data.sink.row.eq(row),
                 self.data.sink.col.eq(col),
+                self.data.sink.bl_width.eq(bl_width),
                 If(~self.data.sink.ready,
-                    self.log.error("Simulator data FIFO overflow")
+                    self.log.error("Simulator data FIFO overflow"),
+                    Finish(),
                 ),
             ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 
     def write_handler(self):
-        bank = Signal(5)
-        row  = Signal(18)
-        col  = Signal(11)
+        bank     = Signal(5)
+        row      = Signal(18)
+        col      = Signal(11)
+        bl_width = Signal(self.bl_max.bit_length())
         auto_precharge = Signal()
 
         return self.cmd_one_step("WRITE",
             cond = self.cs_n_low[:5] == 0b01101,
             comb = [
                 If(~self.cs_n_low[5],
-                   self.log.warn("Command places the DRAM into alternate burst mode; currently unsupported")
-                   ),
+                   Case(self.mode_regs[0][:2], {
+                        0:  bl_width.eq(8),
+                        1:  bl_width.eq(8),
+                        "default": [
+                            self.log.error("Model does not support burst length of 32, setting BL 16", bank, row, col),
+                            bl_width.eq(16),
+                        ],
+                   }),
+                ).Else(
+                    bl_width.eq(16),
+                ),
                 bank.eq(self.cs_n_low[6:11]),
                 row.eq(self.active_rows[bank]),
                 col.eq(Cat(Replicate(0, 3), self.cs_n_high[1:9])),
@@ -401,7 +497,8 @@ class CommandsSim(Module, AutoCSR):
 
                 # sanity checks
                 If(~self.active_banks[bank],
-                    self.log.error("WRITE command on inactive bank: bank=%d row=%d col=%d", bank, row, col)
+                    self.log.error("WRITE command on inactive bank: bank=%d row=%d col=%d", bank, row, col),
+                    Finish(),
                 ),
                 If(auto_precharge,
                     self.log.info("AUTO-PRECHARGE: bank=%d row=%d", bank, row),
@@ -416,10 +513,13 @@ class CommandsSim(Module, AutoCSR):
                 self.data.sink.bank.eq(bank),
                 self.data.sink.row.eq(row),
                 self.data.sink.col.eq(col),
+                self.data.sink.bl_width.eq(bl_width),
                 If(~self.data.sink.ready,
-                    self.log.error("Simulator data FIFO overflow")
+                    self.log.error("Simulator data FIFO overflow"),
+                    Finish(),
                 ),
             ],
+            handle_cmd = self.handle_2_tick_cmd,
         )
 # Data ---------------------------------------------------------------------------------------------
 
@@ -432,11 +532,9 @@ class DataSim(Module, AutoCSR):
 
     This module runs with DDR clocks (simulation clocks with double the frequency of `pads.clk_p`).
     """
-    def __init__(self, pads, cmds_sim, *, cd_dq_wr, cd_dq_rd, cd_dqs_wr, cd_dqs_rd, cl, cwl, clk_freq, log_level):
+    def __init__(self, pads, cmds_sim, *, cd_dq_wr, cd_dq_rd, cd_dqs_wr, cd_dqs_rd, cl, cwl, clk_freq, log_level, bl_max):
         self.submodules.log = log = SimLogger(log_level=log_level, clk_freq=clk_freq)
         self.log.add_csrs()
-
-        bl = 16
 
         dq_dqs_ratio = len(pads.dq) // len(pads.dqs_t)
         if dq_dqs_ratio == 8:
@@ -456,28 +554,75 @@ class DataSim(Module, AutoCSR):
         bank = Signal(5)
         row = Signal(18)
         col = Signal(11)
+        bl_width = Signal(bl_max.bit_length())
 
-        dq_kwargs = dict(bank=bank, row=row, col=col, bl=bl, nrows=nrows, ncols=ncols,
+        dq_kwargs = dict(bank=bank, row=row, col=col, bl_max=bl_max, nrows=nrows, ncols=ncols,
             log_level=log_level, clk_freq=clk_freq)
-        dqs_kwargs = dict(bl=bl, log_level=log_level, clk_freq=clk_freq)
+        dqs_kwargs = dict(bl_max=bl_max, log_level=log_level, clk_freq=clk_freq)
 
-        self.submodules.dq_wr = ClockDomainsRenamer(cd_dq_wr)(DQWrite(dq=pads.dq, dmi=pads.dm_n, ports=ports, **dq_kwargs))
-        self.submodules.dq_rd = ClockDomainsRenamer(cd_dq_rd)(DQRead(dq=pads.dq_i, ports=ports, **dq_kwargs))
-        self.submodules.dqs_wr = ClockDomainsRenamer(cd_dqs_wr)(DQSWrite(dqs=pads.dqs_t, **dqs_kwargs))
-        self.submodules.dqs_rd = ClockDomainsRenamer(cd_dqs_rd)(DQSRead(dqs=pads.dqs_t_i,**dqs_kwargs))
+        self.submodules.dq_wr = ClockDomainsRenamer(cd_dq_wr)(DQWrite(dq=pads.dq, dmi=pads.dm_n,
+                                                              bl_width=bl_width, ports=ports, **dq_kwargs))
+        self.submodules.dq_rd = ClockDomainsRenamer(cd_dq_rd)(DQRead(dq=pads.dq_i, bl_width=bl_width,
+                                                              ports=ports, **dq_kwargs))
+        self.submodules.dqs_wr = ClockDomainsRenamer(cd_dqs_wr)(DQSWrite(dqs=pads.dqs_t, bl_width=bl_width, **dqs_kwargs))
+        self.submodules.dqs_rd = ClockDomainsRenamer(cd_dqs_rd)(DQSRead(dqs=pads.dqs_t_i, bl_width=bl_width, **dqs_kwargs))
 
-        write = Signal()
+        write        = Signal()
+        wr_postamble = Signal(3)
+        wr_postamble_trigger = Signal()
+        wr_postamble_width   = Signal(max=4)
+
+        wr_preamble  = Signal(8)
+        wr_preamble_trigger = Signal()
+        wr_preamble_width   = Signal(max=9)
+
         read = Signal()
 
         read_skew = 1  # shift the read data as in hardware it will be coming with a delay
         self.comb += [
+            Case(cmds_sim.mode_regs[8][3:5] , {
+                0: self.log.error("Write Preamble 0b00 is reserved"),
+                1: wr_preamble_width.eq(4), # nCLK * 2 as we are working with 2*dram freq
+                2: wr_preamble_width.eq(6), #
+                3: wr_preamble_width.eq(8), #
+            }),
+            Case(cmds_sim.mode_regs[8][3:5] , {
+                0: self.log.error("Write Preamble 0b00 is reserved"),
+                1: wr_preamble.eq(0b0100),
+                2: wr_preamble.eq(0b010000),
+                3: wr_preamble.eq(0b01000000),
+            }),
+            Case(cmds_sim.mode_regs[8][7] , {
+                0: wr_postamble_width.eq(1),
+                1: wr_postamble_width.eq(3),
+            }),
+            Case(cmds_sim.mode_regs[8][7] , {
+                0: wr_postamble.eq(0b0),
+                1: wr_postamble.eq(0b000),
+            }),
+            self.log.error("Write Preamble width=%d preamble=%d", wr_preamble_width, wr_preamble),
             write.eq(cmds_sim.data_en.taps[cwl-1] & cmds_sim.data.source.valid & cmds_sim.data.source.we),
+            wr_preamble_trigger.eq(cmds_sim.data_en.taps[cwl - wr_preamble_width[1:] - 1] &
+                                   ~cmds_sim.data_en.taps[cwl - wr_preamble_width] &
+                                   cmds_sim.data.source.valid &
+                                   cmds_sim.data.source.we & ~ClockSignal("sys4x_90")),
+
             read.eq(cmds_sim.data_en.taps[cl-1 + read_skew] & cmds_sim.data.source.valid & ~cmds_sim.data.source.we),
+
             cmds_sim.data.source.ready.eq(write | read),
             self.dq_wr.masked.eq(write & cmds_sim.data.source.masked),
             self.dq_wr.trigger.eq(write),
             self.dq_rd.trigger.eq(read),
+
             self.dqs_wr.trigger.eq(write),
+
+            self.dqs_wr.preamble_trigger.eq(wr_preamble_trigger),
+            self.dqs_wr.preamble_width.eq(wr_preamble_width),
+            [self.dqs_wr.preamble[i].eq(wr_preamble[i]) for i in range(8)],
+
+            self.dqs_wr.postamble_width.eq(wr_postamble_width),
+            [self.dqs_wr.postamble[i].eq(wr_postamble[i]) for i in range(3)],
+
             self.dqs_rd.trigger.eq(read),
         ]
 
@@ -486,18 +631,20 @@ class DataSim(Module, AutoCSR):
                 bank.eq(cmds_sim.data.source.bank),
                 row.eq(cmds_sim.data.source.row),
                 col.eq(cmds_sim.data.source.col),
+                bl_width.eq(cmds_sim.data.source.bl_width),
+                self.log.info("Sync: bl_width=%d", bl_width),
             )
         ]
 
 
 class DataBurst(Module, AutoCSR):
-    def __init__(self, *, bl, log_level, clk_freq):
+    def __init__(self, *, bl_width, bl_max, log_level, clk_freq):
         self.submodules.log = log = SimLogger(log_level=log_level, clk_freq=clk_freq)
         self.log.add_csrs()
 
-        self.bl = bl
-        self.trigger = Signal()
-        self.burst_counter = Signal(max=bl - 1)
+        self.bl       = bl_width
+        self.trigger  = Signal()
+        self.burst_counter = Signal(max=bl_max - 1)
 
     def add_fsm(self, ops, on_trigger=[]):
         self.submodules.fsm = fsm = FSM()
@@ -511,8 +658,11 @@ class DataBurst(Module, AutoCSR):
         fsm.act("BURST",
             *ops,
             NextValue(self.burst_counter, self.burst_counter + 1),
-            If(self.burst_counter == self.bl - 1,
+            If(self.burst_counter == self.bl - 1 & ~self.trigger,
                 NextState("IDLE")
+            ).Elif( self.burst_counter == self.bl -1, # Back to back burst
+                *on_trigger,
+                NextValue(self.burst_counter, 0),
             ),
         )
 
@@ -565,13 +715,73 @@ class DQRead(DQBurst):
 class DQSWrite(DataBurst):
     def __init__(self, *, dqs, **kwargs):
         super().__init__(**kwargs)
-        dqs0 = Signal()
+        dqs0       = Signal()
+        postamble0 = Signal()
+        post_dqs0  = Signal()
+        preamble0  = Signal()
+        pre_dqs0   = Signal()
+        self.preamble_trigger   = Signal()
+        self.preamble_width     = Signal(max=9)
+        self.preamble           = Array(Signal() for _ in range(8))
+
+        self.postamble_width    = Signal(max=4)
+        self.postamble          = Array(Signal() for _ in range(3))
+
         self.add_fsm([
             dqs0.eq(dqs[0]),
             If(dqs[0] != self.burst_counter[0],
                 self.log.warn("Wrong DQS=%d for cycle=%d", dqs0, self.burst_counter, once=False)
             ),
         ])
+
+        post_counter = Signal(max=3)
+        self.submodules.post = post = FSM()
+        post.act("IDLE",
+            NextValue(post_counter, 0),
+            If(self.burst_counter == self.bl - 1 & ~self.trigger,
+                NextState("POSTCOUNT")
+            )
+        )
+        post.act("POSTCOUNT",
+            NextValue(post_counter, post_counter + 1),
+            post_dqs0.eq(dqs[0]),
+            postamble0.eq(self.postamble[post_counter]),
+            If(~self.fsm.ongoing("BURST") &
+               dqs[0] != self.postamble[post_counter],
+                self.log.error("Incorrect DQS postamble on bit=%d, expected:%d, got:%d",
+                                post_counter, postamble0, post_dqs0),
+                Finish()
+            ),
+            If(post_counter == self.postamble_width - 1,
+                NextState("IDLE")
+            ),
+        )
+
+        pre_counter = Signal(max=8)
+        self.submodules.pre = pre = FSM()
+        pre.act("IDLE",
+            NextValue(pre_counter, 0),
+            If(self.preamble_trigger,
+                NextState("PRECOUNT"),
+            )
+        )
+        pre.act("PRECOUNT",
+            NextValue(pre_counter, pre_counter + 1),
+            pre_dqs0.eq(dqs[0]),
+            preamble0.eq(self.preamble[pre_counter]),
+            If(~self.fsm.ongoing("BURST") &
+               ~self.post.ongoing("POSTCOUNT") &
+               dqs[0] != self.preamble[pre_counter],
+                self.log.error("Incorrect DQS preamble on bit=%d, expected:%d, got:%d",
+                                pre_counter, preamble0, pre_dqs0),
+                Finish()
+            ),
+            If(pre_counter == self.preamble_width - 1 & ~self.preamble_trigger,
+                NextState("IDLE")
+            ).Elif( self.burst_counter == self.bl -1, # Back to back burst, can happen only if preamble is 4 clock long and transfers are BL8
+                NextValue(pre_counter, 0),
+            ),
+        )
 
 class DQSRead(DataBurst):
     def __init__(self, *, dqs, **kwargs):

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -585,10 +585,9 @@ class DataSim(Module, AutoCSR):
 
         read = Signal()
 
-        self.submodules.read_dqs_delay = ClockDomainsRenamer(cd_dq_rd)(TappedDelayLine(read))
         self.submodules.write_delay    = ClockDomainsRenamer(cd_dq_wr)(TappedDelayLine(write, ntaps=1))
         self.submodules.masked_delay   = ClockDomainsRenamer(cd_dq_wr)(TappedDelayLine(masked, ntaps=1))
-        self.submodules.read_delay     = ClockDomainsRenamer(cd_dq_rd)(TappedDelayLine(read, ntaps=2))
+        self.submodules.read_delay     = ClockDomainsRenamer(cd_dq_rd)(TappedDelayLine(read, ntaps=1))
 
         self.comb += [
             Case(cmds_sim.mode_regs[8][3:5] , {
@@ -635,7 +634,7 @@ class DataSim(Module, AutoCSR):
             self.dqs_wr.postamble_width.eq(wr_postamble_width),
             [self.dqs_wr.postamble[i].eq(wr_postamble[i]) for i in range(3)],
 
-            self.dqs_rd.trigger.eq(self.read_dqs_delay.output),
+            self.dqs_rd.trigger.eq(read),
         ]
 
         self.comb += [

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -34,10 +34,10 @@ class DDR5Sim(Module, AutoCSR):
     after CL/CWL and a data burst is handled, updating memory state.
 
     The simulator requires the following clock domains:
-        sys8x:        8x the memory controller clock frequency, phase aligned.
-        sys8x_90:     Phase shifted by 90 degrees vs sys8x.
-        sys8x_ddr:    Phase aligned with sys8x, double the frequency.
-        sys8x_90_ddr: Phase aligned with sys8x_90, double the frequency.
+        sys4x:        4x the memory controller clock frequency, phase aligned.
+        sys4x_90:     Phase shifted by 90 degrees vs sys4x.
+        sys4x_ddr:    Phase aligned with sys4x, double the frequency.
+        sys4x_90_ddr: Phase aligned with sys4x_90, double the frequency.
 
     Parameters
     ----------
@@ -58,11 +58,11 @@ class DDR5Sim(Module, AutoCSR):
     def __init__(self, pads, *, sys_clk_freq, cl, cwl, disable_delay, log_level, geom_settings):
         log_level = log_level_getter(log_level)
 
-        cd_cmd    = "sys8x_90"
-        cd_dq_wr  = "sys8x_90_ddr"
-        cd_dqs_wr = "sys8x_ddr"
-        cd_dq_rd  = "sys8x_90_ddr"
-        cd_dqs_rd = "sys8x_ddr"
+        cd_cmd    = "sys4x_90"
+        cd_dq_wr  = "sys4x_90_ddr"
+        cd_dqs_wr = "sys4x_ddr"
+        cd_dq_rd  = "sys4x_90_ddr"
+        cd_dqs_rd = "sys4x_ddr"
 
         self.submodules.data_cdc = ClockDomainCrossing(
             [("we", 1), ("masked", 1), ("bank", geom_settings.bankbits), ("row", 18), ("col", 11)],
@@ -70,7 +70,7 @@ class DDR5Sim(Module, AutoCSR):
 
         cmd = CommandsSim(pads,
             data_cdc      = self.data_cdc,
-            clk_freq      = 8*sys_clk_freq,
+            clk_freq      = 4*sys_clk_freq,
             log_level     = log_level("cmd"),
             geom_settings = geom_settings,
             init_delays   = not disable_delay,
@@ -82,7 +82,7 @@ class DDR5Sim(Module, AutoCSR):
             cd_dqs_wr = cd_dqs_wr,
             cd_dq_rd  = cd_dq_rd,
             cd_dqs_rd = cd_dqs_rd,
-            clk_freq  = 2*8*sys_clk_freq,
+            clk_freq  = 2*4*sys_clk_freq,
             cl        = cl,
             cwl       = cwl,
             log_level = log_level("data"),


### PR DESCRIPTION
Memory model was to loose and allowed for incorrect init sequence and for incorrect Read/Write operations.
This PR is aimed at firming it up, so MC and PHY designs are forced to adhere to JEDEC specification. 
It forces:
* correct delays in initialization sequence
* checks on DQS preamble and postamble 

Adds support or OTF BL16 to BL8 change, this is part of non-optional specification.
BL8 allows for only 4 DFI phases, rather than 8 as it was before.