### PR TITLE
Fix DDR5 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout Repository
       - name: Checkout
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get install wget build-essential python3 ninja-build
           sudo apt-get install libevent-dev libjson-c-dev flex bison
-          sudo apt-get install libfl-dev libfl2 zlibc zlib1g-dev
+          sudo apt-get install libfl-dev libfl2 zlib1g-dev
           pip3 install setuptools
           pip3 install requests
           pip3 install pexpect

--- a/litedram/dfii.py
+++ b/litedram/dfii.py
@@ -214,6 +214,9 @@ class DFIInjector(Module, AutoCSR):
                     # NOP Injector.
                     # -------------
                     2: csr3_dfi.connect(self.master),
+                    # Make Verilator happy :)
+                    # -----------------------
+                    3: (),
                 })
             ]
         else:

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -605,7 +605,7 @@ class DataSim(Module, AutoCSR):
                 0: self.log.error("Write Preamble 0b00 is reserved"),
                 1: wr_preamble.eq(0b0100),
                 2: wr_preamble.eq(0b010000),
-                3: wr_preamble.eq(0b01000000),
+                3: wr_preamble.eq(0b01010000),
             }),
             Case(cmds_sim.mode_regs[8][7] , {
                 0: wr_postamble_width.eq(1),

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -619,7 +619,6 @@ class DataSim(Module, AutoCSR):
                 0: wr_postamble.eq(0b0),
                 1: wr_postamble.eq(0b000),
             }),
-            self.log.error("Write Preamble width=%d preamble=%d", wr_preamble_width, wr_preamble),
             write.eq(cmds_sim.data_en.taps[cwl-2] & cmds_sim.data.source.valid & cmds_sim.data.source.we),
             wr_preamble_trigger.eq(cmds_sim.data_en.taps[cwl - wr_preamble_width[1:] - 2] &
                                    ~cmds_sim.data_en.taps[cwl - wr_preamble_width[1:] - 1] &

--- a/litedram/phy/ddr5/sim.py
+++ b/litedram/phy/ddr5/sim.py
@@ -305,8 +305,12 @@ class CommandsSim(Module, AutoCSR):
                 state: Case(fsm.state, {
                     next_state: self.log.info(f"FSM: {state_name} -> {next_state_name}")
                     for next_state, next_state_name in fsm.decoding.items()
+                } | {
+                    "default": self.log.error(f"FSM: {state_name=} undefined next state")
                 })
                 for state, state_name in fsm.decoding.items()
+            } | {
+                "default": self.log.error(f"FSM: Undefined previous state")
             })
         )
 

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -351,6 +351,10 @@ def main():
         **soc_kwargs)
 
     # Build/Run ------------------------------------------------------------------------------------
+    def pre_run_callback(vns):
+        if args.trace:
+            generate_gtkw_savefile(builder, vns, args.trace_fst)
+
     builder_kwargs["csr_csv"] = "csr.csv"
     builder = Builder(soc, **builder_kwargs)
     build_kwargs = dict(
@@ -358,15 +362,10 @@ def main():
         trace       = args.trace,
         trace_fst   = args.trace_fst,
         trace_start = int(args.trace_start),
-        trace_end   = int(args.trace_end)
+        trace_end   = int(args.trace_end),
+        pre_run_callback = pre_run_callback,
     )
-    vns = builder.build(run=False, **build_kwargs)
-
-    if args.gtkw_savefile:
-        generate_gtkw_savefile(builder, vns, trace_fst=args.trace_fst)
-
-    if not args.no_run:
-        builder.build(build=False, **build_kwargs)
+    builder.build(run=not args.no_run, **build_kwargs)
 
 if __name__ == "__main__":
     main()

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -260,7 +260,6 @@ def generate_gtkw_savefile(builder, vns, trace_fst):
             else:
                 ser_groups = [("out", soc.ddrphy.out)]
             for name, out in ser_groups:
-                print([out.dqs_t_o[0], out.dqs_t_oe, out.dm_n_o[0], out.dm_n_oe])
                 save.group([out.dqs_t_o[0], out.dqs_t_oe, out.dm_n_o[0], out.dm_n_oe],
                     group_name = name,
                     mappers = [

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -29,24 +29,26 @@ from test.phy_common import DFISequencer, PadChecker
 #
 # NOTE: On hardware proper reset must be ensured!
 #
-# The simulation should start like this:
-#   sys          |_--------------
-#   sys_11_25    |___------------
-#   sys8x        |_----____----__
-#   sys8x_ddr    |_--__--__--__--
-#   sys8x_90     |___----____----
-#   sys8x_90_ddr |-__--__--__--__
+# The simulation should start like this (each char is 1 ns):
+#   sys          |_--------------------------------
+#   sys2x        |_----------------________________
+#   sys4x        |_--------________--------________
+#   sys4x_ddr    |_----____----____----____----____
+#   sys4x_90     |_____--------________--------____
+#   sys4x_90_ddr |-____----____----____----____----
+#   sys4x_180    |-________--------________--------
 #
-# sys8x_90_ddr does not trigger at the simulation start (not an edge),
+# sys4x_90_ddr does not trigger at the simulation start (not an edge),
 # BUT a generator starts before first edge, so a `yield` is needed to wait until the first
 # rising edge!
 run_simulation = partial(test.phy_common.run_simulation, clocks={
     "sys":          (64, 31),
     "sys2x":        (32, 15),
-    "sys4x":        ( 8,  3),
-    "sys4x_ddr":    ( 4,  1),
-    "sys4x_90":     ( 8,  1),
-    "sys4x_90_ddr": ( 4,  3),
+    "sys4x":        (16,  7),
+    "sys4x_ddr":    ( 8,  3),
+    "sys4x_90":     (16,  3),
+    "sys4x_90_ddr": ( 8,  7),
+    "sys4x_180":    (16, 15),
 })
 
 dfi_data_to_dq = partial(test.phy_common.dfi_data_to_dq, databits=8, nphases=4, burst=16)

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -132,16 +132,14 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_cs_n_phase_3(self):
         # Test that CS_n is serialized correctly when sending command on phase 3
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-        latency_n = '11111111' * phy.settings.cmd_latency
-
-        self.run_test(dut = phy,
+        self.run_test(
             dfi_sequence = [
                 {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=0)},  # p3: WRITE
             ],
-            pad_checkers = {"sys4x_90": {
-                'cs_n': latency_n + '11101111',
+            pad_checkers = {"sys4x": {
+                'cs_n': self.cs_n_latency + '11101111',
             }},
+            vcd_name="ddr5_cs_n_phase_3.vcd"
         )
 
     def test_ddr5_clk(self):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -441,15 +441,14 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_dq_in_rddata_valid(self):
         # Test that rddata_valid is set with correct delay
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
         dfi_sequence = [
             {0: dict(rddata_en=1)},  # command is issued by MC (appears on next cycle)
-            *[{p: dict(rddata_valid=0) for p in range(8)} for _ in range(phy.settings.read_latency - 1)],  # nothing is sent during write latency
-            {p: dict(rddata_valid=1) for p in range(8)},
+            *[{p: dict(rddata_valid=0) for p in range(self.NPHASES)} for _ in range(self.read_latency)],  # nothing is sent during read latency
+            {p: dict(rddata_valid=1) for p in range(self.NPHASES)},
             {},
         ]
 
-        self.run_test(dut = phy,
+        self.run_test(
             dfi_sequence = dfi_sequence,
             pad_checkers = {},
             pad_generators = {},

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -45,9 +45,6 @@ sim_clocks={
 }
 run_simulation = partial(test.phy_common.run_simulation, clocks=sim_clocks)
 
-dfi_data_to_dq = partial(test.phy_common.dfi_data_to_dq, databits=8, nphases=4, burst=8)
-dq_pattern = partial(test.phy_common.dq_pattern, databits=8, nphases=4, burst=8)
-
 
 class DDR5Tests(unittest.TestCase):
     SYS_CLK_FREQ = 50e6
@@ -78,6 +75,16 @@ class DDR5Tests(unittest.TestCase):
         self.dq_rd_latency:    str = self.xs * 2 + (self.read_latency - 2) * self.zeros  + '0' * (self.NPHASES - 1) * 2
         self.dqs_t_wr_latency: str = self.xs * 2 + (self.cmd_latency + self.write_latency - 1) * self.xs + 'x' * (self.NPHASES - 1) * 2
         self.dq_wr_latency:    str = self.xs * 2 + (self.cmd_latency + self.write_latency) * self.zeros  + '0' * (self.NPHASES - 1) * 2
+
+    @classmethod
+    def dq_pattern(cls, *args, **kwargs) -> str:
+        return test.phy_common.dq_pattern(
+            *args,
+            databits=cls.DATABITS,
+            nphases=cls.NPHASES,
+            burst=cls.BURST_LENGTH,
+            **kwargs,
+        )
 
     def run_test(self, dfi_sequence, pad_checkers: Mapping[str, Mapping[str, str]], pad_generators=None, **kwargs):
         # pad_checkers: {clock: {sig: values}}

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -144,15 +144,14 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_clk(self):
         # Test clock serialization
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-
-        self.run_test(dut = phy,
+        self.run_test(
             dfi_sequence = [
                 {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
             ],
             pad_checkers = {"sys4x_90_ddr": {
-                'clk': '01010101' * (phy.settings.cmd_latency + 1),
+                'ck_t': self.xs * 2 + '10101010' * (self.cmd_latency + 1),
             }},
+            vcd_name="ddr5_clk.vcd"
         )
 
     def test_ddr5_cs_n_multiple_phases(self):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -120,16 +120,14 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_cs_n_phase_0(self):
         # Test that CS_n is serialized correctly when sending command on phase 0
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-        latency_n = '11111111' * phy.settings.cmd_latency
-
-        self.run_test(dut = phy,
+        self.run_test(
             dfi_sequence = [
                 {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # p0: READ
             ],
-            pad_checkers = {"sys4x_90": {
-                'cs_n': latency_n + '01111111',
+            pad_checkers = {"sys4x": {
+                'cs_n': self.cs_n_latency + '01111111',
             }},
+            vcd_name="ddr5_cs_n_phase_0.vcd"
         )
 
     def test_ddr5_cs_n_phase_3(self):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -341,33 +341,28 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_dqs(self):
         # Test serialization of DQS pattern in relation to DQ data, with proper preamble and postamble
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-        zero = '00000000' * 2
-        xs = 'xxxxxxxx' * 2
-        write_latency = phy.settings.write_latency
 
-        self.run_test(dut = phy,
+
+        self.run_test(
             dfi_sequence = [
-                {0: dict(wrdata_en=1)},
-                *[{} for _ in range(write_latency - 1)],
+                {self.wrphase: dict(wrdata_en=1)},
+                *[{} for _ in range(self.write_latency - 1)],
                 {  # to get 10101010... pattern on dq0 and only 1s on others
                     0: dict(wrdata=0xfeff),
                     1: dict(wrdata=0xfeff),
                     2: dict(wrdata=0xfeff),
                     3: dict(wrdata=0xfeff),
-                    4: dict(wrdata=0xfeff),
-                    5: dict(wrdata=0xfeff),
-                    6: dict(wrdata=0xfeff),
-                    7: dict(wrdata=0xfeff),
+                },
+                {
                 },
             ],
             pad_checkers = {
                 "sys4x_90_ddr": {
-                    'dq0':  (phy.settings.cmd_latency + write_latency) * zero + '10101010'+'10101010' + '00000000'+'00000000' + zero,
-                    'dq1':  (phy.settings.cmd_latency + write_latency) * zero + '11111111'+'11111111' + '00000000'+'00000000' + zero,
+                    "dqs_t0": self.dqs_t_wr_latency + 'xxxx0010' + '10101010'+ '0xxxxxxx',
                 },
                 "sys4x_ddr": {
-                    "dqs0": (phy.settings.cmd_latency + write_latency - 1) * xs + 'xxxxxxxx'+'xxxxx001' + '01010101'+'01010101' + '0xxxxxxxx' + xs,
+                    "dq0":  self.dq_wr_latency + '10101010' + self.zeros,
+                    "dq1":  self.dq_wr_latency + '11111111' + self.zeros,
                 }
             },
             vcd_name="ddr5_dqs.vcd"

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -318,32 +318,25 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_dq_only_1cycle(self):
         # Test that DQ data is sent to pads only during expected cycle, on other cycles there is no data
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-        zero = '00000000' * 2
-        write_latency = phy.settings.write_latency
 
         dfi_data = {
             0: dict(wrdata=0x1122),
             1: dict(wrdata=0x3344),
             2: dict(wrdata=0x5566),
             3: dict(wrdata=0x7788),
-            4: dict(wrdata=0x99aa),
-            5: dict(wrdata=0xbbcc),
-            6: dict(wrdata=0xddee),
-            7: dict(wrdata=0xff00),
         }
         dfi_wrdata_en = copy.deepcopy(dfi_data)
-        dfi_wrdata_en[0].update(dict(wrdata_en=1))
+        dfi_wrdata_en[self.wrphase].update(dict(wrdata_en=1))
 
-        self.run_test(dut = phy,
+        self.run_test(
             dfi_sequence = [
                 dfi_wrdata_en,
-                *[dfi_data for _ in range(write_latency)], # only last should be handled
+                *[dfi_data for _ in range(self.write_latency)], # only last should be handled
             ],
-            pad_checkers = {"sys4x_90_ddr": {
-                f'dq{i}': (phy.settings.cmd_latency + write_latency)*zero + dq_pattern(i, dfi_data, "wrdata") + zero for i in range(8)
+            pad_checkers = {"sys4x_ddr": {
+                f'dq{i}': self.dq_wr_latency + self.dq_pattern(i, dfi_data, "wrdata") + self.zeros for i in range(self.DATABITS)
             }},
-            vcd_name="ddr_dq_only_1cycle.vcd"
+            vcd_name="ddr5_dq_only_1cycle.vcd"
         )
 
     def test_ddr5_dqs(self):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -51,8 +51,8 @@ run_simulation = partial(test.phy_common.run_simulation, clocks={
     "sys4x_180":    (16, 15),
 })
 
-dfi_data_to_dq = partial(test.phy_common.dfi_data_to_dq, databits=8, nphases=4, burst=16)
-dq_pattern = partial(test.phy_common.dq_pattern, databits=8, nphases=4, burst=16)
+dfi_data_to_dq = partial(test.phy_common.dfi_data_to_dq, databits=8, nphases=4, burst=8)
+dq_pattern = partial(test.phy_common.dq_pattern, databits=8, nphases=4, burst=8)
 
 
 class DDR5Tests(unittest.TestCase):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -203,30 +203,27 @@ class DDR5Tests(unittest.TestCase):
 
     def test_ddr5_empty_command_sequence(self):
         # Test CS_n/CA values for empty dfi commands sequence
-        phy = DDR5SimPHY(sys_clk_freq=self.SYS_CLK_FREQ)
-        latency   = '00000000' * phy.settings.cmd_latency
-        latency_n = '11111111' * phy.settings.cmd_latency
-
-        self.run_test(dut = phy,
-                      dfi_sequence = [],
-                      pad_checkers = {"sys4x_90": {
-                          'cs_n': latency_n,
-                          'ca0':  latency,
-                          'ca1':  latency,
-                          'ca2':  latency,
-                          'ca3':  latency,
-                          'ca4':  latency,
-                          'ca5':  latency,
-                          'ca6':  latency,
-                          'ca7':  latency,
-                          'ca8':  latency,
-                          'ca9':  latency,
-                          'ca10': latency,
-                          'ca11': latency,
-                          'ca12': latency,
-                          'ca13': latency,
-                      }},
-                      )
+        self.run_test(
+            dfi_sequence = [],
+            pad_checkers = {"sys4x": {
+                'cs_n': self.cs_n_latency,
+                'ca0':  self.ca_latency,
+                'ca1':  self.ca_latency,
+                'ca2':  self.ca_latency,
+                'ca3':  self.ca_latency,
+                'ca4':  self.ca_latency,
+                'ca5':  self.ca_latency,
+                'ca6':  self.ca_latency,
+                'ca7':  self.ca_latency,
+                'ca8':  self.ca_latency,
+                'ca9':  self.ca_latency,
+                'ca10': self.ca_latency,
+                'ca11': self.ca_latency,
+                'ca12': self.ca_latency,
+                'ca13': self.ca_latency,
+            }},
+            vcd_name="ddr5_empty_command_sequence.vcd"
+        )
 
     def test_ddr5_ca_addressing(self):
         # Test that bank/address for different commands are correctly serialized to CA pads


### PR DESCRIPTION
This PR fixes DDR5 tests, by adjusting them to the way PHY works after the rework in [mdudek/DFII-PHY-rework](https://github.com/antmicro/litedram/tree/mdudek/DFII-PHY-rework)