### PR TITLE
Add Verilator tests for DDR5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
           python3 litex_setup.py init install --user
+          # temporary hack until merged to master
+          git -C ../litex remote add antmicro https://github.com/antmicro/litex.git
+          git -C ../litex fetch antmicro
+          git -C ../litex checkout antmicro/4_bit_dqs
 
       # Install RISC-V GCC
       - name: Install RISC-V GCC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           # temporary hack until merged to master
           git -C ../litex remote add antmicro https://github.com/antmicro/litex.git
           git -C ../litex fetch antmicro
-          git -C ../litex checkout antmicro/4_bit_dqs
+          git -C ../litex checkout antmicro/msieron/add-blocking-assign-back
 
       # Install RISC-V GCC
       - name: Install RISC-V GCC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        pytest_args:
+          - 'test                -k "not Verilator"'
+          - 'test/test_lpddr4.py -k "Verilator"'
+          - 'test/test_lpddr5.py -k "Verilator"'
+          - 'test/test_ddr5.py   -k "Verilator"'
     steps:
       # Checkout Repository
       - name: Checkout
@@ -23,6 +31,7 @@ jobs:
           pip3 install requests
           pip3 install pexpect
           pip3 install meson
+          pip3 install pytest
 
       # Install (n)Migen / LiteX / Cores
       - name: Install LiteX
@@ -60,4 +69,4 @@ jobs:
       - name: Run Tests
         run: |
           export PATH=/usr/local/riscv/bin:$PATH
-          python3 setup.py test
+          pytest ${{ matrix.pytest_args }} --verbose

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1293,3 +1293,13 @@ class M329R8GA0BB0(DDR5RegisteredModule):
         "4800": _SpeedgradeTimings(tRP=16, tRCD=16, tWR=30, tRFC=trfc, tFAW=(32, 13.333), tRAS=32),  # TODO: tRAS_max
     }
     speedgrade_timings["default"] = speedgrade_timings["4800"]
+
+
+class DDR5SimX8(MT60B2G8HB48B):
+    # modified so simulation uses less memory in CI
+    nrows       = 2 ** 14
+
+
+class DDR5SimX4(M329R8GA0BB0):
+    # modified so simulation uses less memory in CI
+    nrows       = 2 ** 14

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1269,7 +1269,7 @@ class MT60B2G8HB48B(DDR5Module):
     # the controller during this time, after ZQCAL LATCH we have to wait tZQLAT=max(8ck, 30ns)
     technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(16, 10), tCCD=(32, 20), tRRD=(8, 5), tZQCS=None)
     speedgrade_timings = {
-        "4800": _SpeedgradeTimings(tRP=16, tRCD=16, tWR=30, tRFC=trfc, tFAW=(32, 13.333), tRAS=32),  # TODO: tRAS_max
+        "4800": _SpeedgradeTimings(tRP=16.666, tRCD=16.666, tWR=30, tRFC=trfc, tFAW=(32, 13.333), tRAS=32),  # TODO: tRAS_max
     }
     speedgrade_timings["default"] = speedgrade_timings["4800"]
 

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -321,9 +321,9 @@ class SDRAMModule:
             rowbits  = log2_int(self.nrows),
             colbits  = log2_int(self.ncols),
         )
-        assert not (self.memtype != "DDR4" and fine_refresh_mode != None)
+        assert self.memtype in ("DDR4", "DDR5") or fine_refresh_mode == None
         assert fine_refresh_mode in [None, "1x", "2x", "4x"]
-        if (fine_refresh_mode is None) and (self.memtype == "DDR4"):
+        if (fine_refresh_mode is None) and (self.memtype in ("DDR4", "DDR5")):
             fine_refresh_mode = "1x"
         self.timing_settings = TimingSettings(
             tRP   = self.ck_ns_to_cycles(self.get("tRP")),
@@ -383,6 +383,10 @@ class SDRAMModule:
     def ns_to_cycles(self, t, margin=True):
         clk_period_ns = 1e9/self.clk_freq
         t += self.margin if margin else 0
+
+        if self.memtype == "DDR5":
+            t *= 0.997
+
         return ceil(t/clk_period_ns)
 
     def ck_to_cycles(self, c):
@@ -1163,46 +1167,46 @@ class MT53E256M16D1(SDRAMModule):
     speedgrade_timings["default"] = speedgrade_timings["1866"]
 
 # DDR5 -------------------------------------------------------------------------------------------
+class DDR5Module(SDRAMModule):                     memtype = "DDR5"
+class DDR5RegisteredModule(SDRAMRegisteredModule): memtype = "DDR5"
 
-class MT60B2G8HB48B(SDRAMModule):
-    memtype = "DDR5"
-
-    nbanks = 32
-    nrows = 65536
-    ncols = 1024
-
-    # TODO: These data below is taken from the LPDDR4 module. It needs to be changed and verified
-
-    # TODO: find a way to select if we need masked writes
-    tccd = {"write": (32, 20)}
-
-    # TODO: tZQCS - performing ZQC during runtime will require modifying Refresher, as ZQC has to be done in 2 phases
-    # 1. ZQCAL START is issued 2. ZQCAL LATCH updates the values, the time START->LATCH tZQCAL=1us, so we cannot block
-    # the controller during this time, after ZQCAL LATCH we have to wait tZQLAT=max(8ck, 30ns)
-    technology_timings = _TechnologyTimings(tREFI=32e6/8192, tWTR=(16, 10), tCCD=tccd["write"], tRRD=(8, 5), tZQCS=(30, 8))
-    speedgrade_timings = {
-        "1866": _SpeedgradeTimings(tRP=15.00, tRCD=15.00, tWR=(48, 30), tRFC=260, tFAW=40, tRAS=32),  # TODO: tRAS_max
-    }
-    speedgrade_timings["default"] = speedgrade_timings["1866"]
-
-
-class M329R8GA0BB0(SDRAMModule):
-    memtype = "DDR5"
-
-    nbanks = 32
-    nrows = 2 ** 16
-    ncols = 2 ** 11
-
-    # TODO: These data below is taken from the MT60B2G8HB48B module. It needs to be changed and verified
-
-    # TODO: find a way to select if we need masked writes
-    tccd = {"write": (32, 20)}
+class MT60B2G8HB48B(DDR5Module):
+    #geometry
+    ngroupbanks = 4
+    ngroups     = 8
+    nbanks      = ngroups * ngroupbanks
+    nrows       = 2 ** 16
+    ncols       = 2 ** 10
+    # timings
+    trefi = {"1x": 32e6/8192, "2x": (32e6/8192)/2}
+    trfc  = {"1x": 295, "2x": 160}
 
     # TODO: tZQCS - performing ZQC during runtime will require modifying Refresher, as ZQC has to be done in 2 phases
     # 1. ZQCAL START is issued 2. ZQCAL LATCH updates the values, the time START->LATCH tZQCAL=1us, so we cannot block
     # the controller during this time, after ZQCAL LATCH we have to wait tZQLAT=max(8ck, 30ns)
-    technology_timings = _TechnologyTimings(tREFI=32e6/8192, tWTR=(16, 10), tCCD=tccd["write"], tRRD=(8, 5), tZQCS=(30, 8))
+    technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(16, 10), tCCD=(32, 20), tRRD=(8, 5), tZQCS=None)
     speedgrade_timings = {
-        "1866": _SpeedgradeTimings(tRP=15.00, tRCD=15.00, tWR=(48, 30), tRFC=260, tFAW=40, tRAS=32),  # TODO: tRAS_max
+        "4800": _SpeedgradeTimings(tRP=16, tRCD=16, tWR=30, tRFC=trfc, tFAW=(32, 13.333), tRAS=32),  # TODO: tRAS_max
     }
-    speedgrade_timings["default"] = speedgrade_timings["1866"]
+    speedgrade_timings["default"] = speedgrade_timings["4800"]
+
+
+class M329R8GA0BB0(DDR5RegisteredModule):
+    #geometry
+    ngroupbanks = 4
+    ngroups     = 8
+    nbanks      = ngroups * ngroupbanks
+    nrows       = 2 ** 18
+    ncols       = 2 ** 11
+    # timings
+    trefi = {"1x": 32e6/8192, "2x": (32e6/8192)/2}
+    trfc  = {"1x": 295, "2x": 160}
+
+    # TODO: tZQCS - performing ZQC during runtime will require modifying Refresher, as ZQC has to be done in 2 phases
+    # 1. ZQCAL START is issued 2. ZQCAL LATCH updates the values, the time START->LATCH tZQCAL=1us, so we cannot block
+    # the controller during this time, after ZQCAL LATCH we have to wait tZQLAT=max(8ck, 30ns)
+    technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(16, 10), tCCD=(32, 20), tRRD=(8, 5), tZQCS=None)
+    speedgrade_timings = {
+        "4800": _SpeedgradeTimings(tRP=16, tRCD=16, tWR=30, tRFC=trfc, tFAW=(32, 13.333), tRAS=32),  # TODO: tRAS_max
+    }
+    speedgrade_timings["default"] = speedgrade_timings["4800"]

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -115,9 +115,9 @@ class SimSoC(SoCCore):
 
         # DDR5 -----------------------------------------------------------------------------------
         if dq_dqs_ratio == 8:
-            sdram_module = litedram_modules.MT60B2G8HB48B(sys_clk_freq, "1:4")
+            sdram_module = litedram_modules.DDR5SimX8(sys_clk_freq, "1:4")
         elif dq_dqs_ratio == 4:
-            sdram_module = litedram_modules.M329R8GA0BB0(sys_clk_freq, "1:4")
+            sdram_module = litedram_modules.DDR5SimX4(sys_clk_freq, "1:4")
             if masked_write:
                 masked_write = False
                 print("Masked Write is unsupported for x4 device (JESD79-5A, section 4.8.1)")

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -177,6 +177,12 @@ class SimSoC(SoCCore):
         for name in _speedgrade_timings + _technology_timings:
             timings[name] = sdram_module.get(name)
 
+            if name in ("tRFC", "tREFI"):
+                timings[name] = {
+                    refresh_mode: sdram_module.get(name, refresh_mode)
+                    for refresh_mode in ("1x", "2x")
+                }
+
         self.submodules.dfi_timings_checker = DFITimingsChecker(
             dfi          = self.ddrphy.dfi,
             nbanks       = 2**self.sdram.controller.settings.geom.bankbits,

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -369,6 +369,7 @@ def main():
         trace_start = int(args.trace_start),
         trace_end   = int(args.trace_end),
         pre_run_callback = pre_run_callback,
+        jobs="$(nproc)", # so CI doesn't get killed by OOM
     )
     builder.build(run=not args.no_run, **build_kwargs)
 

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -663,7 +663,7 @@ class VerilatorDDR5Tests(unittest.TestCase):
         import pexpect
 
         command = ["python3", simsoc.__file__, *args]
-        timeout = 12 * 60  # give more than enough time
+        timeout = 30 * 60  # give more than enough time for CI
         p = pexpect.spawn(" ".join(command), timeout=timeout, **kwargs)
 
         res = p.expect(["Memtest OK", "Memtest KO"])

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -676,6 +676,7 @@ class VerilatorDDR5Tests(unittest.TestCase):
         # refresh and no L2 cache (masked write must work)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_ddr5_sim_dq_dqs_ratio_4",
             "--l2-size", "0",
             "--dq-dqs-ratio", "4",
         ])
@@ -685,6 +686,7 @@ class VerilatorDDR5Tests(unittest.TestCase):
         # refresh and no L2 cache (masked write must work)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_ddr5_sim_dq_dqs_ratio_8",
             "--l2-size", "0",
             "--dq-dqs-ratio", "8",
         ])

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -10,10 +10,10 @@ import os
 
 def build_config(name):
     errors = 0
-    os.system("rm -rf examples/build")
-    os.system("cd examples && python3 ../litedram/gen.py {}.yml".format(name))
-    errors += not os.path.isfile("examples/build/gateware/litedram_core.v")
-    os.system("rm -rf examples/build")
+    os.system(f"rm -rf examples/{name}")
+    os.system(f"mkdir -p examples/{name} && cd examples/{name} && python3 ../../litedram/gen.py ../{name}.yml")
+    errors += not os.path.isfile(f"examples/{name}/build/gateware/litedram_core.v")
+    os.system(f"rm -rf examples/{name}")
     return errors
 
 

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -689,6 +689,7 @@ class VerilatorLPDDR4Tests(unittest.TestCase):
         # refresh and no L2 cache (masked write must work)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_lpddr4_sim_x2rate_no_cache",
             "--double-rate-phy",
             "--l2-size", "0",
             "--no-refresh",  # FIXME: LiteDRAM sends refresh commands when only MRW/MRR are allowed
@@ -698,6 +699,7 @@ class VerilatorLPDDR4Tests(unittest.TestCase):
         # Fast test of simulation with L2 cache (so no data masking is required)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_lpddr4_sim_fast",
             "--disable-delay",
             "--no-refresh",
         ])

--- a/test/test_lpddr5.py
+++ b/test/test_lpddr5.py
@@ -746,6 +746,7 @@ class VerilatorLPDDR5Tests(unittest.TestCase):
             with self.subTest(wck_ck_ratio=wck_ck_ratio):
                 self.run_test([
                     "--finish-after-memtest", "--log-level=warn",
+                    "--output-dir", "build/test_lpddr5_sim_no_delays",
                     "--disable-delay",
                     f"--wck-ck-ratio={wck_ck_ratio}",
                     "--no-refresh",  # FIXME: avoids warnings before initialization
@@ -763,6 +764,7 @@ class VerilatorLPDDR5Tests(unittest.TestCase):
                 ]
                 self.run_test([
                     "--finish-after-memtest", "--log-level=warn",
+                    "--output-dir", "build/test_lpddr5_sim_delays_no_cache",
                     "--l2-size=0",
                     f"--wck-ck-ratio={wck_ck_ratio}",
                     "--no-refresh",  # FIXME: LiteDRAM sends refresh commands when only MRW/MRR are allowed


### PR DESCRIPTION
Because DDR5 requires a fix to LiteX (https://github.com/enjoy-digital/litex/pull/1401), this PR is a draft.
After https://github.com/enjoy-digital/litex/pull/1401 gets merged, 2f857d6be1fc86309deb05f509ff8b35318916be can be removed and then this PR should be mergable.

---

Added Verilator tests based on LPDDR4 tests.
One small change is, looking for errors in simulation logs is only performed after memory init, because before that we can get bogus errors.

Updated data for DDR5 in modules.py and added support for SPD.

Added special modules just for simulation with reduced number of rows. Otherwise memory requirements for host running those tests can be massive (Verilator errors with: `Width of bit range is huge; vector of over 1billion bits: 0x20000000`).

To let CI pass, I had to also reduce number of concurrent `make` jobs for DDR5. Otherwise compilation of the simulation was taking too much memory.

I also modified existing tests to make them output their generated files into separate build directories. This allows to run them in parallel with `pytest --workers auto test` (requires [pytest](https://pypi.org/project/pytest/) and [pytest-parallel](https://pypi.org/project/pytest-parallel/)). On my machine it reduce time to run all tests from 30 min to 7 min.

Finally to make CI runs faster, I split it into 4 jobs:
- run all non-Verilator tests
- run Verilator tests for LPDDR4
- run Verilator tests for LPDDR5
- run Verilator tests for DDR5

This halves CI workflow time.