### PR TITLE
Configurable DDR timings with CSR

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -423,10 +423,13 @@ class tFAWController(Module):
         # # #
 
         if tfaw is not None:
-            count  = Signal(max=max(tfaw, 2))
-            window = Signal(tfaw)
+            count  = Signal(max=max(tfaw.nbits, 2))
+            window = Signal(tfaw.nbits)
+            window_pass = Signal(tfaw.nbits)
             self.sync += window.eq(Cat(valid, window))
-            self.comb += count.eq(reduce(add, [window[i] for i in range(tfaw)]))
+            for i in range(tfaw.nbits):
+                self.comb += If(tfaw > i, window_pass[i].eq(window[i])).Else(window_pass[i].eq(0))
+            self.comb += count.eq(reduce(add, [window_pass[i] for i in range(tfaw.nbits)]))
             self.sync += \
                 If(count < 4,
                     If(count == 3,

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -435,3 +435,21 @@ class tFAWController(Module):
                         ready.eq(1)
                     )
                 )
+
+
+class TimelineCounter(Module):
+    def __init__(self, width):
+        self.counter = Signal(width)
+        self.target = Signal(self.counter.nbits)
+        self.trigger = Signal()
+
+        self.sync += [
+            If(self.counter != 0,
+                self.counter.eq(self.counter + 1)
+            ).Elif(self.trigger,
+                self.counter.eq(1)
+            ),
+            If(self.counter == self.target,
+                self.counter.eq(0)
+            ),
+        ]

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -391,24 +391,24 @@ class LiteDRAMNativeReadPort(LiteDRAMNativePort):
 class tXXDController(Module):
     def __init__(self, txxd):
         self.valid = valid = Signal()
-        self.ready = ready = Signal(reset=txxd is None)
+        self.ready = ready = Signal()
         ready.attr.add("no_retiming")
 
         # # #
 
         if txxd is not None:
-            count = Signal(max=max(txxd, 2))
+            count = Signal(max(txxd.nbits, 2))
             self.sync += \
                 If(valid,
                     count.eq(txxd - 1),
-                    If((txxd - 1) == 0,
+                    If(txxd <= 1,
                         ready.eq(1)
                     ).Else(
                         ready.eq(0)
                     )
                 ).Elif(~ready,
                     count.eq(count - 1),
-                    If(count == 1,
+                    If(count <= 1,
                         ready.eq(1)
                     )
                 )

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -95,6 +95,14 @@ class BankMachine(Module):
         ba = settings.geom.bankbits + log2_int(nranks)
         self.cmd = cmd = stream.Endpoint(cmd_request_rw_layout(a, ba))
 
+        self.timer = Signal(max(timing_regs['tRP'].nbits, timing_regs['tRCD'].nbits) + 1)
+        self.timer_done = Signal()
+
+        # # #
+
+        self.comb += self.timer_done.eq(self.timer == 0)
+        self.sync += If(~self.timer_done, self.timer.eq(self.timer - 1))
+
         # # #
 
         auto_precharge = Signal()
@@ -203,6 +211,7 @@ class BankMachine(Module):
             If(twtpcon.ready & trascon.ready,
                 cmd.valid.eq(1),
                 If(cmd.ready,
+                    NextValue(self.timer, timing_regs['tRP'] - 1),
                     NextState("TRP")
                 ),
                 cmd.ras.eq(1),
@@ -213,9 +222,15 @@ class BankMachine(Module):
         )
         fsm.act("AUTOPRECHARGE",
             If(twtpcon.ready & trascon.ready,
+                NextValue(self.timer, timing_regs['tRP'] - 1),
                 NextState("TRP")
             ),
             row_close.eq(1)
+        )
+        fsm.act("TRP",
+            If(self.timer_done,
+                NextState("ACTIVATE")
+            )
         )
         fsm.act("ACTIVATE",
             If(trccon.ready,
@@ -224,9 +239,15 @@ class BankMachine(Module):
                 cmd.valid.eq(1),
                 cmd.is_cmd.eq(1),
                 If(cmd.ready,
+                    NextValue(self.timer, timing_regs['tRCD'] - 1),
                     NextState("TRCD")
                 ),
                 cmd.ras.eq(1)
+            )
+        )
+        fsm.act("TRCD",
+            If(self.timer_done,
+                NextState("REGULAR")
             )
         )
         fsm.act("REFRESH",
@@ -239,5 +260,3 @@ class BankMachine(Module):
                 NextState("REGULAR")
             )
         )
-        fsm.delayed_enter("TRP", "ACTIVATE", timing_regs['tRP'] - 1)
-        fsm.delayed_enter("TRCD", "REGULAR", timing_regs['tRCD'] - 1)

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -86,7 +86,7 @@ class BankMachine(Module):
     cmd : Endpoint(cmd_request_rw_layout)
         Stream of commands to the Multiplexer
     """
-    def __init__(self, n, address_width, address_align, nranks, settings):
+    def __init__(self, n, address_width, address_align, nranks, settings, timing_regs):
         self.req = req = Record(cmd_layout(address_width))
         self.refresh_req = refresh_req = Signal()
         self.refresh_gnt = refresh_gnt = Signal()
@@ -143,16 +143,18 @@ class BankMachine(Module):
 
         # tWTP (write-to-precharge) controller -----------------------------------------------------
         write_latency = math.ceil(settings.phy.cwl / settings.phy.nphases)
-        precharge_time = write_latency + settings.timing.tWR + settings.timing.tCCD # AL=0
-        self.submodules.twtpcon = twtpcon = tXXDController(precharge_time)
+        precharge_time = write_latency + timing_regs['tWR'] + timing_regs['tCCD'] # AL=0
+        precharge_time_sig = Signal(max(write_latency.bit_length(), timing_regs['tWR'].nbits, timing_regs['tCCD'].nbits) + 1)
+        self.comb += precharge_time_sig.eq(precharge_time)
+        self.submodules.twtpcon = twtpcon = tXXDController(precharge_time_sig)
         self.comb += twtpcon.valid.eq(cmd.valid & cmd.ready & cmd.is_write)
 
         # tRC (activate-activate) controller -------------------------------------------------------
-        self.submodules.trccon = trccon = tXXDController(settings.timing.tRC)
+        self.submodules.trccon = trccon = tXXDController(timing_regs['tRC'])
         self.comb += trccon.valid.eq(cmd.valid & cmd.ready & row_open)
 
         # tRAS (activate-precharge) controller -----------------------------------------------------
-        self.submodules.trascon = trascon = tXXDController(settings.timing.tRAS)
+        self.submodules.trascon = trascon = tXXDController(timing_regs['tRAS'])
         self.comb += trascon.valid.eq(cmd.valid & cmd.ready & row_open)
 
         # Auto Precharge generation ----------------------------------------------------------------
@@ -237,5 +239,5 @@ class BankMachine(Module):
                 NextState("REGULAR")
             )
         )
-        fsm.delayed_enter("TRP", "ACTIVATE", settings.timing.tRP - 1)
-        fsm.delayed_enter("TRCD", "REGULAR", settings.timing.tRCD - 1)
+        fsm.delayed_enter("TRP", "ACTIVATE", timing_regs['tRP'] - 1)
+        fsm.delayed_enter("TRCD", "REGULAR", timing_regs['tRCD'] - 1)

--- a/litedram/core/controller.py
+++ b/litedram/core/controller.py
@@ -9,6 +9,7 @@
 
 from migen import *
 
+from litex.soc.interconnect.csr import CSRStorage, AutoCSR
 from litedram.common import *
 from litedram.phy import dfi
 from litedram.core.refresher import Refresher
@@ -43,6 +44,30 @@ class ControllerSettings(Settings):
         address_mapping     = "ROW_BANK_COL"):
         self.set_attributes(locals())
 
+
+REGISTER_NAMES = ("tRP", "tRCD", "tWR", "tWTR", "tREFI", "tRFC", "tFAW", "tCCD", "tRRD", "tRC", "tRAS", "tZQCS")
+class LiteDRAMControllerRegisterBank(Module, AutoCSR):
+    def __init__(self, initial_timings):
+        for reg in REGISTER_NAMES:
+            try:
+                reset_val = getattr(initial_timings, reg)
+            except AttributeError:
+                reset_val = None
+            csr = CSRStorage(32, name=reg, reset=reset_val if reset_val is not None else 0)
+            setattr(self, reg, csr)
+
+    def get_register_signals(self):
+        regs = {}
+        for reg in REGISTER_NAMES:
+            try:
+                csr = getattr(self, reg)
+            except AttributeError:
+                continue
+            if csr is not None:
+                regs[reg] = csr.storage
+        return regs
+
+
 # Controller ---------------------------------------------------------------------------------------
 
 class LiteDRAMController(Module):
@@ -63,6 +88,11 @@ class LiteDRAMController(Module):
         nranks = phy_settings.nranks
         nbanks = 2**geom_settings.bankbits
 
+        # Registers --------------------------------------------------------------------------------
+
+        self.registers = registers = LiteDRAMControllerRegisterBank(timing_settings)
+        timing_regs = registers.get_register_signals()
+
         # LiteDRAM Interface (User) ----------------------------------------------------------------
         self.interface = interface = LiteDRAMInterface(address_align, self.settings)
 
@@ -78,9 +108,10 @@ class LiteDRAMController(Module):
 
         # Refresher --------------------------------------------------------------------------------
         self.submodules.refresher = self.settings.refresh_cls(self.settings,
-            clk_freq   = clk_freq,
-            zqcs_freq  = self.settings.refresh_zqcs_freq,
-            postponing = self.settings.refresh_postponing)
+            clk_freq    = clk_freq,
+            timing_regs = timing_regs,
+            zqcs_freq   = self.settings.refresh_zqcs_freq,
+            postponing  = self.settings.refresh_postponing)
 
         # Bank Machines ----------------------------------------------------------------------------
         bank_machines = []
@@ -89,7 +120,8 @@ class LiteDRAMController(Module):
                 address_width = interface.address_width,
                 address_align = address_align,
                 nranks        = nranks,
-                settings      = self.settings)
+                settings      = self.settings,
+                timing_regs   = timing_regs)
             bank_machines.append(bank_machine)
             self.submodules += bank_machine
             self.comb += getattr(interface, "bank"+str(n)).connect(bank_machine.req)
@@ -100,7 +132,8 @@ class LiteDRAMController(Module):
             bank_machines = bank_machines,
             refresher     = self.refresher,
             dfi           = self.dfi,
-            interface     = interface)
+            interface     = interface,
+            timing_regs   = timing_regs)
 
     def get_csrs(self):
-        return self.multiplexer.get_csrs()
+        return self.multiplexer.get_csrs() + self.registers.get_csrs()

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -220,7 +220,8 @@ class Multiplexer(Module, AutoCSR):
             bank_machines,
             refresher,
             dfi,
-            interface):
+            interface,
+            timing_regs):
         assert(settings.phy.nphases == len(dfi.phases))
 
         ras_allowed = Signal(reset=1)
@@ -260,18 +261,18 @@ class Multiplexer(Module, AutoCSR):
         self.submodules += steerer
 
         # tRRD timing (Row to Row delay) -----------------------------------------------------------
-        self.submodules.trrdcon = trrdcon = tXXDController(settings.timing.tRRD)
+        self.submodules.trrdcon = trrdcon = tXXDController(timing_regs['tRRD'])
         self.comb += trrdcon.valid.eq(choose_cmd.accept() & choose_cmd.activate())
 
         # tFAW timing (Four Activate Window) -------------------------------------------------------
-        self.submodules.tfawcon = tfawcon = tFAWController(settings.timing.tFAW)
+        self.submodules.tfawcon = tfawcon = tFAWController(timing_regs['tFAW'])
         self.comb += tfawcon.valid.eq(choose_cmd.accept() & choose_cmd.activate())
 
         # RAS control ------------------------------------------------------------------------------
         self.comb += ras_allowed.eq(trrdcon.ready & tfawcon.ready)
 
         # tCCD timing (Column to Column delay) -----------------------------------------------------
-        self.submodules.tccdcon = tccdcon = tXXDController(settings.timing.tCCD)
+        self.submodules.tccdcon = tccdcon = tXXDController(timing_regs['tCCD'])
         self.comb += tccdcon.valid.eq(choose_req.accept() & (choose_req.write() | choose_req.read()))
 
         # CAS control ------------------------------------------------------------------------------
@@ -279,10 +280,13 @@ class Multiplexer(Module, AutoCSR):
 
         # tWTR timing (Write to Read delay) --------------------------------------------------------
         write_latency = math.ceil(settings.phy.cwl / settings.phy.nphases)
-        self.submodules.twtrcon = twtrcon = tXXDController(
-            settings.timing.tWTR + write_latency +
-            # tCCD must be added since tWTR begins after the transfer is complete
-            settings.timing.tCCD if settings.timing.tCCD is not None else 0)
+        twtrcon_init = Signal(max=timing_regs['tWTR'].nbits + write_latency + timing_regs['tCCD'].nbits)
+        self.comb += twtrcon_init.eq(timing_regs['tWTR'] + write_latency + timing_regs['tCCD'])
+        # self.submodules.twtrcon = twtrcon = tXXDController(
+        #     timing_regs['tWTR'] + write_latency +
+        #     # tCCD must be added since tWTR begins after the transfer is complete
+        #     timing_regs['tCCD'] if timing_regs['tCCD'] is not None else 0)
+        self.submodules.twtrcon = twtrcon = tXXDController(twtrcon_init)
         self.comb += twtrcon.valid.eq(choose_req.accept() & choose_req.write())
 
         # Read/write turnaround --------------------------------------------------------------------

--- a/litedram/core/refresher.py
+++ b/litedram/core/refresher.py
@@ -26,8 +26,10 @@ class RefreshExecuter(Module):
     - Wait tRFC
     """
     def __init__(self, cmd, trp, trfc):
-        self.start = Signal()
-        self.done  = Signal()
+        self.start    = Signal()
+        self.done     = Signal()
+        self.trp      = Signal(trp.nbits)
+        self.trp_trfc = Signal(max(trfc.nbits, trp.nbits) + 1)
 
         # # #
 
@@ -38,6 +40,10 @@ class RefreshExecuter(Module):
             cmd.ras.eq(0),
             cmd.we.eq( 0),
             self.done.eq(0),
+            If(self.start,
+                self.trp.eq(trp),
+                self.trp_trfc.eq(trfc + trp)
+            ),
             # Wait start
             timeline(self.start, [
                 # Precharge All
@@ -49,7 +55,7 @@ class RefreshExecuter(Module):
                     cmd.we.eq( 1)
                 ]),
                 # Auto Refresh after tRP
-                (trp, [
+                (self.trp, [
                     cmd.a.eq(  2**10),  # all banks in LPDDR4/DDR5, ignored in other memories
                     cmd.ba.eq( 0),
                     cmd.cas.eq(1),
@@ -57,7 +63,7 @@ class RefreshExecuter(Module):
                     cmd.we.eq( 0),
                 ]),
                 # Done after tRP + tRFC
-                (trp + trfc, [
+                (self.trp_trfc, [
                     cmd.a.eq(  0),
                     cmd.ba.eq( 0),
                     cmd.cas.eq(0),
@@ -107,18 +113,20 @@ class RefreshTimer(Module):
     def __init__(self, trefi):
         self.wait  = Signal()
         self.done  = Signal()
-        self.count = Signal(bits_for(trefi))
+        self.count = Signal(trefi.nbits)
 
         # # #
 
         done  = Signal()
-        count = Signal(bits_for(trefi), reset=trefi-1)
+        count = Signal(trefi.nbits)
 
         self.sync += [
             If(self.wait & ~self.done,
                 count.eq(count - 1)
             ).Else(
-                count.eq(count.reset)
+                If(trefi != 0,
+                    count.eq(trefi-1)
+                )
             )
         ]
         self.comb += [
@@ -218,7 +226,7 @@ class Refresher(Module):
     transactions are done, the Refresher can execute the refresh Sequence and release the Controller.
 
     """
-    def __init__(self, settings, clk_freq, zqcs_freq=1e0, postponing=1):
+    def __init__(self, settings, clk_freq, timing_regs, zqcs_freq=1e0, postponing=1):
         assert postponing <= 8
         abits  = settings.geom.addressbits
         babits = settings.geom.bankbits + log2_int(settings.phy.nranks)
@@ -230,9 +238,9 @@ class Refresher(Module):
         wants_zqcs    = Signal()
 
         # Refresh Timer ----------------------------------------------------------------------------
-        if settings.timing.tREFI < 100: # FIXME: Reduce Margin.
-            raise ValueError("Clk/tREFI is ratio too low , please increase Clk frequency or disable Refresh.")
-        timer = RefreshTimer(settings.timing.tREFI)
+        # if settings.timing.tREFI < 100: # FIXME: Reduce Margin.
+        #     raise ValueError("Clk/tREFI is ratio too low , please increase Clk frequency or disable Refresh.")
+        timer = RefreshTimer(timing_regs['tREFI'])
         self.submodules.timer = timer
         self.comb += timer.wait.eq(~timer.done)
 
@@ -243,17 +251,17 @@ class Refresher(Module):
         self.comb += wants_refresh.eq(postponer.req_o)
 
         # Refresh Sequencer ------------------------------------------------------------------------
-        sequencer = RefreshSequencer(cmd, settings.timing.tRP, settings.timing.tRFC, postponing)
+        sequencer = RefreshSequencer(cmd, timing_regs['tRP'], timing_regs['tRFC'], postponing)
         self.submodules.sequencer = sequencer
 
         if settings.timing.tZQCS is not None:
             # ZQCS Timer ---------------------------------------------------------------------------
             zqcs_timer = RefreshTimer(int(clk_freq/zqcs_freq))
             self.submodules.zqcs_timer = zqcs_timer
-            self.comb += wants_zqcs.eq(zqcs_timer.done)
+            self.comb += If(timing_regs['tZQCS'] > 0, wants_zqcs.eq(zqcs_timer.done)).Else(wants_zqcs.eq(0))
 
             # ZQCS Executer ------------------------------------------------------------------------
-            zqcs_executer = ZQCSExecuter(cmd, settings.timing.tRP, settings.timing.tZQCS)
+            zqcs_executer = ZQCSExecuter(cmd, timing_regs['tRP'], timing_regs['tZQCS'])
             self.submodules.zqs_executer = zqcs_executer
             self.comb += zqcs_timer.wait.eq(~zqcs_executer.done)
 

--- a/litedram/core/refresher.py
+++ b/litedram/core/refresher.py
@@ -26,12 +26,18 @@ class RefreshExecuter(Module):
     - Wait tRFC
     """
     def __init__(self, cmd, trp, trfc):
-        self.start    = Signal()
-        self.done     = Signal()
-        self.trp      = Signal(trp.nbits)
-        self.trp_trfc = Signal(max(trfc.nbits, trp.nbits) + 1)
+        self.start = Signal()
+        self.done  = Signal()
 
         # # #
+
+        tlc = TimelineCounter(max(trp.nbits, trfc.nbits) + 1)
+        self.submodules += tlc
+
+        self.comb += [
+            tlc.trigger.eq(self.start),
+            tlc.target.eq(trp+trfc),
+        ]
 
         self.sync += [
             cmd.a.eq(  0),
@@ -40,38 +46,30 @@ class RefreshExecuter(Module):
             cmd.ras.eq(0),
             cmd.we.eq( 0),
             self.done.eq(0),
-            If(self.start,
-                self.trp.eq(trp),
-                self.trp_trfc.eq(trfc + trp)
+        ]
+        self.sync += [
+            If(tlc.trigger & (tlc.counter == 0),
+                cmd.a.eq(  2**10),
+                cmd.ba.eq( 0),
+                cmd.cas.eq(0),
+                cmd.ras.eq(1),
+                cmd.we.eq( 1)
             ),
-            # Wait start
-            timeline(self.start, [
-                # Precharge All
-                (0, [
-                    cmd.a.eq(  2**10),
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(0),
-                    cmd.ras.eq(1),
-                    cmd.we.eq( 1)
-                ]),
-                # Auto Refresh after tRP
-                (self.trp, [
-                    cmd.a.eq(  2**10),  # all banks in LPDDR4/DDR5, ignored in other memories
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(1),
-                    cmd.ras.eq(1),
-                    cmd.we.eq( 0),
-                ]),
-                # Done after tRP + tRFC
-                (self.trp_trfc, [
-                    cmd.a.eq(  0),
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(0),
-                    cmd.ras.eq(0),
-                    cmd.we.eq( 0),
-                    self.done.eq(1),
-                ]),
-            ])
+            If(tlc.counter == trp,
+                cmd.a.eq(  2**10),  # all banks in LPDDR4/DDR5, ignored in other memories
+                cmd.ba.eq( 0),
+                cmd.cas.eq(1),
+                cmd.ras.eq(1),
+                cmd.we.eq( 0),
+            ),
+            If(tlc.counter == (trp + trfc),
+                cmd.a.eq(  0),  # all banks in LPDDR4/DDR5, ignored in other memories
+                cmd.ba.eq( 0),
+                cmd.cas.eq(0),
+                cmd.ras.eq(0),
+                cmd.we.eq( 0),
+                self.done.eq(1),
+            )
         ]
 
 # RefreshSequencer ---------------------------------------------------------------------------------
@@ -174,40 +172,48 @@ class ZQCSExecuter(Module):
     def __init__(self, cmd, trp, tzqcs):
         self.start = Signal()
         self.done  = Signal()
+        self.trp = Signal(trp.nbits)
+        self.tzqcs = Signal(tzqcs.nbits)
 
         # # #
+
+        tlc = TimelineCounter(max(trp.nbits, tzqcs.nbits) + 1)
+        self.submodules += tlc
 
         self.sync += [
             # Note: Don't set cmd to 0 since already done in RefreshExecuter
             self.done.eq(0),
-            # Wait start
-            timeline(self.start, [
-                # Precharge All
-                (0, [
-                    cmd.a.eq(  2**10),
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(0),
-                    cmd.ras.eq(1),
-                    cmd.we.eq( 1)
-                ]),
-                # ZQ Short Calibration after tRP
-                (trp, [
-                    cmd.a.eq(  0),
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(0),
-                    cmd.ras.eq(0),
-                    cmd.we.eq( 1),
-                ]),
-                # Done after tRP + tZQCS
-                (trp + tzqcs, [
-                    cmd.a.eq(  0),
-                    cmd.ba.eq( 0),
-                    cmd.cas.eq(0),
-                    cmd.ras.eq(0),
-                    cmd.we.eq( 0),
-                    self.done.eq(1)
-                ]),
-            ])
+            If(self.start,
+                tlc.trigger.eq(1),
+                tlc.target.eq(trp+tzqcs),
+                self.trp.eq(trp),
+                self.tzqcs.eq(tzqcs),
+            ),
+        ]
+
+        self.sync += [
+            If(tlc.trigger & tlc.counter == 0,
+                cmd.a.eq(  2**10),
+                cmd.ba.eq( 0),
+                cmd.cas.eq(0),
+                cmd.ras.eq(1),
+                cmd.we.eq( 1)
+            ),
+            If(tlc.counter == self.trp,
+                cmd.a.eq(  0),
+                cmd.ba.eq( 0),
+                cmd.cas.eq(0),
+                cmd.ras.eq(0),
+                cmd.we.eq( 1),
+            ),
+            If(tlc.counter == self.trp + self.tzqcs,
+                cmd.a.eq(  0),
+                cmd.ba.eq( 0),
+                cmd.cas.eq(0),
+                cmd.ras.eq(0),
+                cmd.we.eq( 0),
+                self.done.eq(1),
+            )
         ]
 
 # Refresher ----------------------------------------------------------------------------------------

--- a/litedram/core/refresher.py
+++ b/litedram/core/refresher.py
@@ -254,9 +254,10 @@ class Refresher(Module):
         sequencer = RefreshSequencer(cmd, timing_regs['tRP'], timing_regs['tRFC'], postponing)
         self.submodules.sequencer = sequencer
 
-        if settings.timing.tZQCS is not None:
+        if timing_regs['tZQCS'] is not None:
             # ZQCS Timer ---------------------------------------------------------------------------
-            zqcs_timer = RefreshTimer(int(clk_freq/zqcs_freq))
+            zqcs_timer_init = Signal(reset=int(clk_freq/zqcs_freq))
+            zqcs_timer = RefreshTimer(zqcs_timer_init)
             self.submodules.zqcs_timer = zqcs_timer
             self.comb += If(timing_regs['tZQCS'] > 0, wants_zqcs.eq(zqcs_timer.done)).Else(wants_zqcs.eq(0))
 

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -1016,6 +1016,24 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
 
     return r.generate()
 
+REGISTER_NAMES = ("tRP", "tRCD", "tWR", "tWTR", "tREFI", "tRFC", "tFAW", "tCCD", "tRRD", "tRC", "tRAS", "tZQCS")
+
+def get_sdram_timings_c_header(timing_settings):
+    r = CGenerator()
+    r.header_guard("__GENERATED_SDRAM_TIMINGS_H")
+    r.newline()
+
+    for reg in REGISTER_NAMES:
+        try:
+            reg_val = getattr(timing_settings, reg)
+        except AttributeError:
+            reg_val = None
+        r.define("SDRAM_TIMINGS_DEFAULT_{}".format(reg.upper()), reg_val if reg_val is not None else 0)
+
+    r.newline()
+
+    return r.generate()
+
 # Python Header ------------------------------------------------------------------------------------
 
 def get_sdram_phy_py_header(phy_settings, timing_settings):

--- a/test/test_bankmachine.py
+++ b/test/test_bankmachine.py
@@ -11,6 +11,7 @@ from migen import *
 
 from litedram.common import *
 from litedram.core.bankmachine import BankMachine
+from litedram.core.controller import LiteDRAMControllerRegisterBank
 
 from test.common import timeout_generator
 
@@ -74,11 +75,15 @@ class BankMachineDUT(Module):
         self.address_align = log2_int(burst_lengths[settings.phy.memtype])
         self.address_width = LiteDRAMInterface(self.address_align, settings).address_width
 
+        self.submodules.registers = LiteDRAMControllerRegisterBank(settings.timing)
+        timing_regs = self.registers.get_register_signals()
+
         bankmachine = BankMachine(n=n,
             address_width = self.address_width,
             address_align = self.address_align,
             nranks        = settings.phy.nranks,
-            settings      = settings)
+            settings      = settings,
+            timing_regs   = timing_regs)
         self.submodules.bankmachine = bankmachine
 
     def get_cmd(self):

--- a/test/test_multiplexer.py
+++ b/test/test_multiplexer.py
@@ -16,6 +16,7 @@ from litex.soc.interconnect import stream
 from litedram.common import *
 from litedram.phy import dfi
 from litedram.core.multiplexer import Multiplexer
+from litedram.core.controller import LiteDRAMControllerRegisterBank
 
 # load after "* imports" to avoid using Migen version of vcd.py
 from litex.gen.sim import run_simulation
@@ -125,9 +126,13 @@ class MultiplexerDUT(Module):
         address_align = log2_int(burst_lengths[settings.phy.memtype])
         self.interface = LiteDRAMInterface(address_align=address_align, settings=settings)
 
+        # Add Registers
+        self.submodules.registers = LiteDRAMControllerRegisterBank(settings.timing)
+        timing_regs = self.registers.get_register_signals()
+
         # Add Multiplexer
         self.submodules.multiplexer = Multiplexer(settings, self.bank_machines, self.refresher,
-            self.dfi, self.interface)
+            self.dfi, self.interface, timing_regs)
 
         # Add helpers for driving bank machines/refresher
         self.bm_drivers = [CmdRequestRWDriver(bm.cmd, i) for i, bm in enumerate(self.bank_machines)]

--- a/test/test_refresh.py
+++ b/test/test_refresh.py
@@ -10,6 +10,7 @@ from migen import *
 
 from litedram.core.multiplexer import cmd_request_rw_layout
 from litedram.core.refresher import RefreshSequencer, RefreshTimer, Refresher
+from litedram.core.controller import LiteDRAMControllerRegisterBank
 
 
 def c2bool(c):
@@ -21,15 +22,21 @@ class TestRefresh(unittest.TestCase):
         def generator(dut):
             dut.errors = 0
             for start, done, cas, ras in zip(starts, dones, cmds.cas, cmds.ras):
-                yield dut.start.eq(c2bool(start))
+                yield dut.sequencer.start.eq(c2bool(start))
                 yield
-                if (yield dut.done) != c2bool(done):
+                if (yield dut.sequencer.done) != c2bool(done):
                     dut.errors += 1
                 if (yield cmd.cas) != c2bool(cas):
                     dut.errors += 1
                 if (yield cmd.ras) != c2bool(ras):
                     dut.errors += 1
-        dut = RefreshSequencer(cmd, trp, trfc)
+        class DUT(Module):
+            def __init__(self, cmd, trp, trfc):
+                trp_sig = Signal(32, reset=trp)
+                trfc_sig = Signal(32, reset=trfc)
+                self.submodules.sequencer = RefreshSequencer(cmd, trp_sig, trfc_sig)
+
+        dut = DUT(cmd, trp, trfc)
         run_simulation(dut, [generator(dut)])
         self.assertEqual(dut.errors, 0)
 
@@ -47,6 +54,8 @@ class TestRefresh(unittest.TestCase):
     def refresh_timer_test(self, trefi):
         def generator(dut):
             dut.errors = 0
+            if (yield dut.refresh.done) != 0:
+                yield
             for i in range(16*trefi):
                 if i%trefi == (trefi - 1):
                     if (yield dut.refresh.done) != 1:
@@ -58,7 +67,8 @@ class TestRefresh(unittest.TestCase):
 
         class DUT(Module):
             def __init__(self, trefi):
-                self.submodules.refresh = RefreshTimer(trefi)
+                trefi_sig = Signal(32, reset=trefi)
+                self.submodules.refresh = RefreshTimer(trefi_sig)
                 self.comb += self.refresh.wait.eq(~self.refresh.done)
 
         dut = DUT(trefi)
@@ -88,22 +98,28 @@ class TestRefresh(unittest.TestCase):
 
         def generator(dut):
             dut.errors = 0
-            yield dut.cmd.ready.eq(1)
+            yield dut.refresher.cmd.ready.eq(1)
             for i in range(16):
-                while (yield dut.cmd.valid) == 0:
+                while (yield dut.refresher.cmd.valid) == 0:
                     yield
                 cmd_valid_gap = 0
-                while (yield dut.cmd.valid) == 1:
+                while (yield dut.refresher.cmd.valid) == 1:
                     cmd_valid_gap += 1
                     yield
-                while (yield dut.cmd.valid) == 0:
+                while (yield dut.refresher.cmd.valid) == 0:
                     cmd_valid_gap += 1
                     yield
                 if cmd_valid_gap != postponing*settings.timing.tREFI:
                     print(cmd_valid_gap)
                     dut.errors += 1
 
-        dut = Refresher(settings, clk_freq=100e6, postponing=postponing)
+        class DUT(Module):
+            def __init__(self, settings, clk_freq, postponing):
+                self.registers = LiteDRAMControllerRegisterBank(settings.timing)
+                timing_regs = self.registers.get_register_signals()
+                self.submodules.refresher = Refresher(settings=settings, clk_freq=clk_freq, timing_regs=timing_regs, postponing=postponing)
+
+        dut = DUT(settings, clk_freq=100e6, postponing=postponing)
         run_simulation(dut, [generator(dut)])
         self.assertEqual(dut.errors, 0)
 

--- a/test/test_timing.py
+++ b/test/test_timing.py
@@ -28,7 +28,8 @@ class TestTiming(unittest.TestCase):
         
         class DUT(Module):
             def __init__(self, txxd):
-                txxd_sig = Signal(32, reset=txxd)
+                txxd_sig = Signal(32)
+                self.comb += txxd_sig.eq(txxd)
                 self.submodules.txxd = tXXDController(txxd_sig)
 
         dut = DUT(txxd)
@@ -38,22 +39,22 @@ class TestTiming(unittest.TestCase):
     def test_txxd_controller(self):
         txxd = 1
         valids = "__-______"
-        readys = "_--------"
+        readys = "---------"
         self.txxd_controller_test(txxd, valids, readys)
 
         txxd = 2
         valids = "__-______"
-        readys = "_--_-----"
+        readys = "---_-----"
         self.txxd_controller_test(txxd, valids, readys)
 
         txxd = 3
         valids = "____-______"
-        readys = "___--__----"
+        readys = "-----__----"
         self.txxd_controller_test(txxd, valids, readys)
 
         txxd = 4
         valids = "____-______"
-        readys = "___--___---"
+        readys = "-----___---"
         self.txxd_controller_test(txxd, valids, readys)
 
     def txxd_controller_random_test(self, txxd, loops):
@@ -69,6 +70,8 @@ class TestTiming(unittest.TestCase):
         @passive
         def checker(dut):
             dut.ready_gaps = []
+            while (yield dut.txxd.valid) == 0:
+                yield
             while True:
                 while (yield dut.txxd.ready) != 0:
                     yield
@@ -80,7 +83,8 @@ class TestTiming(unittest.TestCase):
 
         class DUT(Module):
             def __init__(self, txxd):
-                txxd_sig = Signal(32, reset=txxd)
+                txxd_sig = Signal(32)
+                self.comb += txxd_sig.eq(txxd)
                 self.submodules.txxd = tXXDController(txxd_sig)
 
         dut = DUT(txxd)

--- a/test/test_timing.py
+++ b/test/test_timing.py
@@ -21,12 +21,17 @@ class TestTiming(unittest.TestCase):
         def generator(dut):
             dut.errors = 0
             for valid, ready in zip(valids, readys):
-                yield dut.valid.eq(c2bool(valid))
+                yield dut.txxd.valid.eq(c2bool(valid))
                 yield
-                if (yield dut.ready) != c2bool(ready):
+                if (yield dut.txxd.ready) != c2bool(ready):
                     dut.errors += 1
+        
+        class DUT(Module):
+            def __init__(self, txxd):
+                txxd_sig = Signal(32, reset=txxd)
+                self.submodules.txxd = tXXDController(txxd_sig)
 
-        dut = tXXDController(txxd)
+        dut = DUT(txxd)
         run_simulation(dut, [generator(dut)])
         self.assertEqual(dut.errors, 0)
 
@@ -57,23 +62,28 @@ class TestTiming(unittest.TestCase):
             for l in range(loops):
                 while prng.randrange(100) < valid_rand:
                     yield
-                yield dut.valid.eq(1)
+                yield dut.txxd.valid.eq(1)
                 yield
-                yield dut.valid.eq(0)
+                yield dut.txxd.valid.eq(0)
 
         @passive
         def checker(dut):
             dut.ready_gaps = []
             while True:
-                while (yield dut.ready) != 0:
+                while (yield dut.txxd.ready) != 0:
                     yield
                 ready_gap = 1
-                while (yield dut.ready) != 1:
+                while (yield dut.txxd.ready) != 1:
                     ready_gap += 1
                     yield
                 dut.ready_gaps.append(ready_gap)
 
-        dut = tXXDController(txxd)
+        class DUT(Module):
+            def __init__(self, txxd):
+                txxd_sig = Signal(32, reset=txxd)
+                self.submodules.txxd = tXXDController(txxd_sig)
+
+        dut = DUT(txxd)
         run_simulation(dut, [generator(dut, valid_rand=90), checker(dut)])
         self.assertEqual(min(dut.ready_gaps), txxd)
 
@@ -87,12 +97,17 @@ class TestTiming(unittest.TestCase):
         def generator(dut):
             dut.errors = 0
             for valid, ready in zip(valids, readys):
-                yield dut.valid.eq(c2bool(valid))
+                yield dut.tfaw.valid.eq(c2bool(valid))
                 yield
-                if (yield dut.ready) != c2bool(ready):
+                if (yield dut.tfaw.ready) != c2bool(ready):
                     dut.errors += 1
 
-        dut = tFAWController(txxd)
+        class DUT(Module):
+            def __init__(self, txxd):
+                txxd_sig = Signal(32, reset=txxd)
+                self.submodules.tfaw = tFAWController(txxd_sig)
+
+        dut = DUT(txxd)
         run_simulation(dut, [generator(dut)])
         self.assertEqual(dut.errors, 0)
 


### PR DESCRIPTION
This PR adds support for DRAM timings configuration from software instead of hardcoding configuration in gateware.
`liblitedram` and BIOS changes: https://github.com/antmicro/litex/pull/9