### PR TITLE
S7PHY ddr5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           pip3 install requests
           pip3 install pexpect
           pip3 install meson
-          pip3 install pytest
+          pip3 install pytest==7.1.0
       - name: Install pytest-parallel
         if: ${{ contains(matrix.pytest_args, 'not') }}
         run: pip install pytest-parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           # temporary hack until merged to master
           git -C ../litex remote add antmicro https://github.com/antmicro/litex.git
           git -C ../litex fetch antmicro
-          git -C ../litex checkout antmicro/msieron/add-blocking-assign-back
+          git -C ../litex checkout antmicro/mdudek/liblitedram_ddr5support
 
       # Install RISC-V GCC
       - name: Install RISC-V GCC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,18 @@ jobs:
       # Install Tools
       - name: Install Tools
         run: |
-          sudo apt-get install wget build-essential python3 ninja-build
-          sudo apt-get install libevent-dev libjson-c-dev flex bison
-          sudo apt-get install libfl-dev libfl2 zlib1g-dev
+          sudo apt-get update
+          sudo apt-get install wget build-essential python3 ninja-build -y
+          sudo apt-get install libevent-dev libjson-c-dev flex bison git -y
+          sudo apt-get install libfl-dev libfl2 zlib1g-dev python3-pip autoconf -y
           pip3 install setuptools
           pip3 install requests
           pip3 install pexpect
           pip3 install meson
           pip3 install pytest
+      - name: Install pytest-parallel
+        if: ${{ contains(matrix.pytest_args, 'not') }}
+        run: pip install pytest-parallel
 
       # Install (n)Migen / LiteX / Cores
       - name: Install LiteX
@@ -52,10 +56,12 @@ jobs:
           sudo cp -r $PWD/../riscv64-*/* /usr/local/riscv
 
       - name: Build Verilator
+        if: ${{ !contains(matrix.pytest_args, 'not') }}
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout v4.228
           autoconf
           ./configure
           make -j$(nproc)
@@ -67,6 +73,13 @@ jobs:
 
       # Test
       - name: Run Tests
+        if: ${{ contains(matrix.pytest_args, 'not') }}
+        run: |
+          export PATH=/usr/local/riscv/bin:$PATH
+          pytest ${{ matrix.pytest_args }} --verbose --workers auto
+
+      - name: Run Tests
+        if: ${{ !contains(matrix.pytest_args, 'not') }}
         run: |
           export PATH=/usr/local/riscv/bin:$PATH
           pytest ${{ matrix.pytest_args }} --verbose

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -146,7 +146,7 @@ class BitSlip(Module):
         # # #
 
         value = Signal(max=cycles*dw, reset=cycles*dw-1)
-        self.sync += If(self.slp, value.eq(value + 1))
+        self.sync += If(self.slp, value.eq(value - 1))
         self.sync += If(self.rst, value.eq(value.reset))
 
         r = Signal((cycles+1)*dw, reset_less=True)
@@ -225,6 +225,7 @@ class PhySettings(Settings):
             cmd_delay: Optional[int] = None,  # used to force cmd delay during initialization in BIOS
             bitslips: int = 0,  # number of write/read bitslip taps
             delays: int = 0,  # number of write/read delay taps
+            with_per_dq_idelay: bool = False,
             # PHY training capabilities
             write_leveling: bool = False,
             write_dq_dqs_training: bool = False,

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -27,7 +27,7 @@ burst_lengths = {
     "DDR3":   8,
     "RPC":    16,
     "DDR4":   8,
-    "DDR5":   16,
+    "DDR5":   8,
     "LPDDR4": 16,
     "LPDDR5": 16,
 }

--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -856,7 +856,7 @@ def main():
     builder_arguments = builder_argdict(args)
     builder_arguments["compile_gateware"] = False
 
-    soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0x8000)
+    soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0xC000)
     builder = Builder(soc, **builder_arguments)
     builder.build(build_name=args.name, regular_comb=False)
 

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -803,6 +803,8 @@ def get_ddr5_phy_init_sequence(phy_settings, timing_settings):
     cl = phy_settings.cl
     bl = 8
 
+    dq_dqs_ratio = phy_settings.databits // phy_settings.strobes
+
     mr = {}
     mr[0] = reg([
         (0, 2, {16: 0b00,
@@ -823,7 +825,11 @@ def get_ddr5_phy_init_sequence(phy_settings, timing_settings):
     mr[2] = reg([
         (1, 1, 0b0),  # write leveling disabled
     ])
-    mr[5] = reg([(5, 1, 0b1)]) # DM enabled
+    mr[5] = reg([(5, 1, {
+            4:  0b0,
+            8:  0b1,
+            16: 0b1,
+        }[dq_dqs_ratio])])
     mr[6] = reg([(0, 8, 0b00000000)])
     mr[8] = reg([
         (0, 3, 0b000),
@@ -1093,6 +1099,9 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
     if phy_settings.is_rdimm:
         assert phy_settings.memtype == "DDR4"
         r.define("SDRAM_PHY_DDR4_RDIMM")
+    if phy_settings.memtype == "DDR5":
+        if phy_settings.with_sub_channels:
+            r.define("SDRAM_PHY_SUBCHANNELS")
 
     r.newline()
 
@@ -1130,8 +1139,6 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
         r.define("DDRX_MR_WRLVL_ADDRESS", 2)
         r.define("DDRX_MR_WRLVL_RESET", mr[2])
         r.define("DDRX_MR_WRLVL_BIT", 7)
-        if phy_settings.with_sub_channels:
-            r.define("SRAM_PHY_SUBCHANNELS")
         r.newline()
     elif phy_settings.memtype in ["LPDDR5"]:
         # Write leveling enabled by MR18[6]

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -1085,6 +1085,8 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
     r.define("SDRAM_PHY_MODULES", phy_settings.strobes)
     if phy_settings.delays > 0:
         r.define("SDRAM_PHY_DELAYS", phy_settings.delays)
+        if phy_settings.with_per_dq_idelay:
+            r.define("SDRAM_DELAY_PER_DQ")
     if phy_settings.bitslips > 0:
         r.define("SDRAM_PHY_BITSLIPS", phy_settings.bitslips)
 

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -1130,6 +1130,8 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
         r.define("DDRX_MR_WRLVL_ADDRESS", 2)
         r.define("DDRX_MR_WRLVL_RESET", mr[2])
         r.define("DDRX_MR_WRLVL_BIT", 7)
+        if phy_settings.with_sub_channels:
+            r.define("SRAM_PHY_SUBCHANNELS")
         r.newline()
     elif phy_settings.memtype in ["LPDDR5"]:
         # Write leveling enabled by MR18[6]

--- a/litedram/phy/ddr5/basephy.py
+++ b/litedram/phy/ddr5/basephy.py
@@ -665,14 +665,18 @@ class DDR5PHY(Module, AutoCSR):
                 for phase in self.dfi.phases
             ]
 
-    def get_rst(self, byte, rst, prefix=""):
+    def get_rst(self, byte, rst, prefix="", clk="sys"):
+        cd_clk = getattr(self.sync, clk)
         t = Signal()
-        self.comb += t.eq((getattr(self, prefix+'dly_sel').storage[byte] & rst) | self._rst.storage)
+        cd_clk += t.eq((getattr(self, prefix+'dly_sel').storage[byte] & rst) | self._rst.storage)
         t.attr.add("mr_ff")
+        t.attr.add("keep")
         return t
 
-    def get_inc(self, byte, inc, prefix=""):
+    def get_inc(self, byte, inc, prefix="", clk="sys"):
+        cd_clk = getattr(self.sync, clk)
         t = Signal()
-        self.comb += t.eq(getattr(self, prefix+"dly_sel").storage[byte] & inc)
+        cd_clk += t.eq(getattr(self, prefix+"dly_sel").storage[byte] & inc)
         t.attr.add("mr_ff")
+        t.attr.add("keep")
         return t

--- a/litedram/phy/ddr5/basephy.py
+++ b/litedram/phy/ddr5/basephy.py
@@ -552,8 +552,8 @@ class DDR5PHY(Module, AutoCSR):
                 old_tap       = old_tap,
                 now_tap       = now_tap,
                 next_tap      = next_tap,
-                wlevel_en     = getattr(self, prefix+'_wlevel_en').storage,
-                wlevel_strobe = getattr(self, prefix+'_wlevel_strobe').re)
+                wlevel_en     = getattr(self, prefix+'wlevel_en').storage,
+                wlevel_strobe = getattr(self, prefix+'wlevel_strobe').re)
             self.submodules += dqs_pattern
 
             dq_oe        = Signal(2*nphases)
@@ -564,22 +564,28 @@ class DDR5PHY(Module, AutoCSR):
                 # output
                 dqs_bitslip    = BitSlip(8,
                     i      = dqs_pattern.o,
-                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip_rst']) | self._rst.storage,
-                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip'],
+                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] &
+                              getattr(self, prefix+'wdly_dq_bitslip_rst').re) |
+                             self._rst.storage,
+                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & getattr(self, prefix+'wdly_dq_bitslip').re,
                     cycles = 1)
                 self.submodules += dqs_bitslip
 
                 dqs_oe_bitslip    = BitSlip(8,
                     i      = dqs_pattern.oe,
-                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip_rst']) | self._rst.storage,
-                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip'],
+                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] &
+                              getattr(self, prefix+'wdly_dq_bitslip_rst').re) |
+                            self._rst.storage,
+                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & getattr(self, prefix+'wdly_dq_bitslip').re,
                     cycles = 1)
                 self.submodules += dqs_oe_bitslip
 
                 dq_oe_bitslip    = BitSlip(8,
                     i      = dq_pattern.oe,
-                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip_rst']) | self._rst.storage,
-                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip'],
+                    rst    = (getattr(self, prefix+'dly_sel').storage[byte] &
+                              getattr(self, prefix+'wdly_dq_bitslip_rst').re) |
+                             self._rst.storage,
+                    slp    = getattr(self, prefix+'dly_sel').storage[byte] & getattr(self, prefix+'wdly_dq_bitslip').re,
                     cycles = 1)
                 self.submodules += dq_oe_bitslip
 
@@ -604,8 +610,10 @@ class DDR5PHY(Module, AutoCSR):
                     ]
                     dm_o_bitslip = BitSlip(8,
                         i      = dm_i,
-                        rst    = (getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip_rst']) | self._rst.storage,
-                        slp    = getattr(self, prefix+'dly_sel').storage[byte] & _l[prefix+'wdly_dq_bitslip'],
+                        rst    = (getattr(self, prefix+'dly_sel').storage[byte] &
+                                  getattr(self, prefix+'wdly_dq_bitslip_rst').re) |
+                                 self._rst.storage,
+                        slp    = getattr(self, prefix+'dly_sel').storage[byte] & getattr(self, prefix+'wdly_dq_bitslip').re,
                         cycles = 1)
 
                     self.submodules += dm_o_bitslip
@@ -624,9 +632,10 @@ class DDR5PHY(Module, AutoCSR):
                 ]
                 dq_o_bitslip = BitSlip(8,
                     i      = Cat(*wrdata),
-                    rst    = (getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & \
-                              _l[prefix+'wdly_dq_bitslip_rst']) | self._rst.storage,
-                    slp    = getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & _l[prefix+'wdly_dq_bitslip'],
+                    rst    = (getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] &
+                              getattr(self, prefix+'wdly_dq_bitslip_rst').re) |
+                              self._rst.storage,
+                    slp    = getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & getattr(self, prefix+'wdly_dq_bitslip').re,
                     cycles = 1)
 
                 self.submodules += dq_o_bitslip
@@ -636,9 +645,10 @@ class DDR5PHY(Module, AutoCSR):
                 dq_i_bs = Signal(2*nphases)
                 dq_i_bitslip = BitSlip(8,
                     i      = getattr(self.out, prefix+'dq_i')[bit],
-                    rst    = (getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & \
-                              _l[prefix+'rdly_dq_bitslip_rst']) | self._rst.storage,
-                    slp    = getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & _l[prefix+'rdly_dq_bitslip'],
+                    rst    = (getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] &
+                              getattr(self, prefix+'rdly_dq_bitslip_rst').re) |
+                             self._rst.storage,
+                    slp    = getattr(self, prefix+'dly_sel').storage[bit//dq_dqs_ratio] & getattr(self, prefix+'rdly_dq_bitslip').re,
                     cycles = 1)
                 self.submodules += dq_i_bitslip
 

--- a/litedram/phy/ddr5/basephy.py
+++ b/litedram/phy/ddr5/basephy.py
@@ -537,30 +537,28 @@ class DDR5PHY(Module, AutoCSR):
 
             # Assumptions: nphases = 4
 
-            older_tap  = Signal(4)
             old_tap  = Signal(4)
             now_tap  = Signal(4)
             next_tap = Signal(4)
 
             # wrtap is at least 5
             self.comb += [
-                older_tap.eq(Cat(wrdata_en.taps[wrtap + 1][1:], wrdata_en.taps[wrtap    ][0])),
-                old_tap.eq(  Cat(wrdata_en.taps[wrtap    ][1:], wrdata_en.taps[wrtap - 1][0])),
-                now_tap.eq(  Cat(wrdata_en.taps[wrtap - 1][1:], wrdata_en.taps[wrtap - 2][0])),
-                next_tap.eq( Cat(wrdata_en.taps[wrtap - 2][1:], wrdata_en.taps[wrtap - 3][0])),
+                old_tap.eq( Cat(wrdata_en.taps[wrtap + 1][1:], wrdata_en.taps[wrtap    ][0])),
+                now_tap.eq( Cat(wrdata_en.taps[wrtap    ][1:], wrdata_en.taps[wrtap - 1][0])),
+                next_tap.eq(Cat(wrdata_en.taps[wrtap - 1][1:], wrdata_en.taps[wrtap - 2][0])),
             ]
 
             dqs_oe        = Signal(2*nphases)
             dqs_pattern   = DDR5DQSPattern(
-                old_tap       = older_tap,
-                now_tap       = old_tap,
-                next_tap      = now_tap,
+                old_tap       = old_tap,
+                now_tap       = now_tap,
+                next_tap      = next_tap,
                 wlevel_en     = getattr(self, prefix+'_wlevel_en').storage,
                 wlevel_strobe = getattr(self, prefix+'_wlevel_strobe').re)
             self.submodules += dqs_pattern
 
             dq_oe        = Signal(2*nphases)
-            dq_pattern   = DDR5DQOePattern(old_tap=older_tap, now_tap=old_tap)
+            dq_pattern   = DDR5DQOePattern(old_tap=old_tap, now_tap=now_tap)
             self.submodules += dq_pattern
 
             for byte in range(strobes):

--- a/litedram/phy/ddr5/basephy.py
+++ b/litedram/phy/ddr5/basephy.py
@@ -38,18 +38,18 @@ class DDR5Output:
 
             setattr(self, prefix+'dq_o',  [Signal(2*nphases) for _ in range(databits)])
             setattr(self, prefix+'dq_i',  [Signal(2*nphases) for _ in range(databits)])
-            setattr(self, prefix+'dq_oe', Signal())  # no serialization
+            setattr(self, prefix+'dq_oe', Signal(2*nphases))
 
             setattr(self, prefix+'dm_n_o',  [Signal(2*nphases) for _ in range(nstrobes)])
             setattr(self, prefix+'dm_n_i',  [Signal(2*nphases) for _ in range(nstrobes)])
-            setattr(self, prefix+'dm_n_oe', Signal())  # no serialization
+            setattr(self, prefix+'dm_n_oe', Signal(2*nphases))
 
             setattr(self, prefix+'dqs_t_o',  [Signal(2*nphases) for _ in range(nstrobes)])
             setattr(self, prefix+'dqs_t_i',  [Signal(2*nphases) for _ in range(nstrobes)])
-            setattr(self, prefix+'dqs_t_oe', Signal())  # no serialization
+            setattr(self, prefix+'dqs_t_oe', Signal(2*nphases))
             setattr(self, prefix+'dqs_c_o',  [Signal(2*nphases) for _ in range(nstrobes)])
             setattr(self, prefix+'dqs_c_i',  [Signal(2*nphases) for _ in range(nstrobes)])
-            setattr(self, prefix+'dqs_c_oe', Signal())  # no serialization
+            setattr(self, prefix+'dqs_c_oe', Signal(2*nphases))
 
 
 class DDR5DQSPattern(Module):

--- a/litedram/phy/ddr5/s7phy.py
+++ b/litedram/phy/ddr5/s7phy.py
@@ -22,14 +22,13 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                  with_per_dq_idelay=False, with_sub_channels=False, **kwargs):
         self.iodelay_clk_freq = iodelay_clk_freq
 
-        with_sub_channels = kwargs.get("with_sub_channels", False)
-
         # DoubleRateDDR5PHY outputs half-width signals (comparing to DDR5PHY) in sys2x domain.
         # This allows us to use 8:1 DDR OSERDESE2/ISERDESE2 to (de-)serialize the data.
         super().__init__(pads,
-            ser_latency = Latency(sys2x=1),  # OSERDESE2 4:1 DDR (2 full-rate clocks)
-            des_latency = Latency(sys=2),  # ISERDESE2 NETWORKING
-            phytype     = self.__class__.__name__,
+            ser_latency       = Latency(sys2x=1),  # OSERDESE2 4:1 DDR (2 full-rate clocks)
+            des_latency       = Latency(sys=2),  # ISERDESE2 NETWORKING
+            phytype           = self.__class__.__name__,
+            with_sub_channels = with_sub_channels,
             **kwargs
         )
 
@@ -46,10 +45,10 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         assert iodelay_clk_freq in [200e6, 300e6, 400e6]
         iodelay_tap_average = 1 / (2*32 * iodelay_clk_freq)
         half_sys4x_taps = math.floor(self.tck / (4 * iodelay_tap_average))
-        assert half_sys8x_taps < 32, "Exceeded ODELAYE2 max value: {} >= 32".format(half_sys8x_taps)
+        assert half_sys4x_taps < 32, "Exceeded ODELAYE2 max value: {} >= 32".format(half_sys4x_taps)
 
         # Registers --------------------------------------------------------------------------------
-        self._half_sys8x_taps = CSRStorage(5, reset=half_sys8x_taps)
+        self._half_sys8x_taps = CSRStorage(5, reset=half_sys4x_taps)
 
         # delay control
         self._rdly_dq_rst  = CSR()
@@ -118,11 +117,11 @@ class S7DDR5PHY(DDR5PHY, S7Common):
             if hasattr(self.pads, const):
                 self.comb += getattr(self.pads, const).eq(0)
 
-        for cmd in ["reset_n", "alert_n"]:
+        for cmd in ["reset_n"]:
             cmd_i = getattr(self.out, cmd)
             cmd_o = getattr(self.pads, cmd)
             cmd_ser = Signal()
-            self.oserdese2_sdr(din=cmd_i, dout=cmd_ser if with_odelay else cmd_o, clk="sys4x")
+            self.oserdese2_ddr(din=cmd_i, dout=cmd_ser if with_odelay else cmd_o, clk="sys4x")
             if with_odelay:
                 self.odelaye2(din=cmd_ser, dout=cmd_o, rst=cdly_rst, inc=cdly_inc)
 
@@ -162,7 +161,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.oserdese2_ddr(
                     din     = dqs_din,
                     **(dict(dout_fb=dqs_ser) if with_odelay else dict(dout=dqs_dly)),
-                    tin     = ~oe_delay_dqs(getattr(self.out, prefix+"dqs_t_oe")),
+                    tin     = ~oe_delay_dqs(getattr(self.out, prefix+"dqs_oe")),
                     tout    = dqs_t,
                     clk     = "sys4x" if with_odelay else "sys4x_90",
                 )

--- a/litedram/phy/ddr5/s7phy.py
+++ b/litedram/phy/ddr5/s7phy.py
@@ -26,8 +26,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         # DoubleRateDDR5PHY outputs half-width signals (comparing to DDR5PHY) in sys2x domain.
         # This allows us to use 8:1 DDR OSERDESE2/ISERDESE2 to (de-)serialize the data.
         super().__init__(pads,
-            ser_latency = Latency(sys2x=1),  # OSERDESE2 8:1 DDR (4 full-rate clocks)
-            des_latency = Latency(sys2x=2),  # ISERDESE2 NETWORKING
+            ser_latency = Latency(sys=1),  # OSERDESE2 8:1 DDR (4 full-rate clocks)
+            des_latency = Latency(sys=2),  # ISERDESE2 NETWORKING
             phytype     = self.__class__.__name__,
             **kwargs
         )
@@ -44,7 +44,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         # Note: this should be named sys16x, but using sys8x due to a name hard-coded in BIOS
         assert iodelay_clk_freq in [200e6, 300e6, 400e6]
         iodelay_tap_average = 1 / (2*32 * iodelay_clk_freq)
-        half_sys8x_taps = math.floor(self.tck / (4 * iodelay_tap_average))
+        half_sys4x_taps = math.floor(self.tck / (4 * iodelay_tap_average))
         assert half_sys8x_taps < 32, "Exceeded ODELAYE2 max value: {} >= 32".format(half_sys8x_taps)
 
         # Registers --------------------------------------------------------------------------------

--- a/litedram/phy/ddr5/s7phy.py
+++ b/litedram/phy/ddr5/s7phy.py
@@ -18,7 +18,8 @@ from litedram.phy.ddr5.basephy import DDR5PHY
 from litedram.phy.s7common import S7Common
 
 class S7DDR5PHY(DDR5PHY, S7Common):
-    def __init__(self, pads, *, iodelay_clk_freq, with_odelay, **kwargs):
+    def __init__(self, pads, *, iodelay_clk_freq, with_odelay,
+                 with_per_dq_idelay=False, with_sub_channels=False, **kwargs):
         self.iodelay_clk_freq = iodelay_clk_freq
 
         with_sub_channels = kwargs.get("with_sub_channels", False)
@@ -26,7 +27,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         # DoubleRateDDR5PHY outputs half-width signals (comparing to DDR5PHY) in sys2x domain.
         # This allows us to use 8:1 DDR OSERDESE2/ISERDESE2 to (de-)serialize the data.
         super().__init__(pads,
-            ser_latency = Latency(sys=1),  # OSERDESE2 8:1 DDR (4 full-rate clocks)
+            ser_latency = Latency(sys2x=1),  # OSERDESE2 4:1 DDR (2 full-rate clocks)
             des_latency = Latency(sys=2),  # ISERDESE2 NETWORKING
             phytype     = self.__class__.__name__,
             **kwargs

--- a/litedram/phy/ddr5/s7phy.py
+++ b/litedram/phy/ddr5/s7phy.py
@@ -24,7 +24,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
 
         def cdc(i):
             o = Signal()
-            psync = PulseSynchronizer("sys", "sys2x_unbuf")
+            psync = PulseSynchronizer("sys", "sys2x")
             self.submodules += psync
             self.comb += [
                 psync.i.eq(i),
@@ -68,7 +68,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         ck_t = self.out.ck_t
         cdc_ck_t = Signal(len(ck_t)//2)
         simple_cdc = SimpleCDC(
-            clkdiv="sys", clk="sys2x_unbuf",
+            clkdiv="sys", clk="sys2x",
             i_dw=len(ck_t), o_dw=len(cdc_ck_t),
             i=ck_t, o=cdc_ck_t,
             name=f"ck_t",
@@ -87,7 +87,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         reset_n = self.out.reset_n
         cdc_reset_n = Signal(len(reset_n)//2)
         simple_cdc = SimpleCDC(
-            clkdiv="sys", clk="sys2x_unbuf",
+            clkdiv="sys", clk="sys2x",
             i_dw=len(reset_n), o_dw=len(cdc_reset_n),
             i=reset_n, o=cdc_reset_n,
             name=f"reset_n",
@@ -109,7 +109,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.sync += delay_out_cs.eq(basephy_cs)
                 cdc_out_cs = Signal(len(delay_out_cs)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(delay_out_cs), o_dw=len(cdc_out_cs),
                     i=delay_out_cs, o=cdc_out_cs,
                     name=f"{prefix}cs_n_{it}",
@@ -138,7 +138,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.sync += out_ca.eq(Cat(delay_ca, basephy_ca[0:-1]))
                 cdc_out_ca = Signal(len(out_ca)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(out_ca), o_dw=len(cdc_out_ca),
                     i=out_ca, o=cdc_out_ca,
                     name=f"{prefix}ca_{it}",
@@ -155,8 +155,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                     self.odelaye2(
                         din=ca_ser,
                         dout=pad,
-                        rst=self.get_rst(it, _l[prefix+'cadly_rst'], prefix),
-                        inc=self.get_inc(it, _l[prefix+'cadly_inc'], prefix),
+                        rst=self.get_rst(it, _l[prefix+'cadly_rst'], prefix, "sys2x"),
+                        inc=self.get_inc(it, _l[prefix+'cadly_inc'], prefix, "sys2x"),
                         clk="sys2x_unbuf",
                     )
 
@@ -170,7 +170,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.sync += out_par.eq(Cat(delay_par, basephy_par[0:-1]))
                 cdc_out_par = Signal(len(basephy_par)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(out_par), o_dw=len(cdc_out_par),
                     i=out_par, o=cdc_out_par,
                     name=f"{prefix}par_{it}",
@@ -198,7 +198,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 dqs_t_o = getattr(self.out, prefix+'dqs_t_o')[it]
                 cdc_dqs_t_o = Signal(len(dqs_t_o)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(dqs_t_o), o_dw=len(cdc_dqs_t_o),
                     i=dqs_t_o, o=cdc_dqs_t_o,
                     name=f"{prefix}dqs_t_o_{it}",
@@ -209,7 +209,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 out_dqs_oe = getattr(self.out, prefix+'dqs_oe')[it]
                 cdc_out_dqs_oe = Signal(len(out_dqs_oe)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(out_dqs_oe), o_dw=len(cdc_out_dqs_oe),
                     i=out_dqs_oe, o=cdc_out_dqs_oe,
                     name=f"{prefix}dqs_t_oe",
@@ -234,8 +234,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                     self.odelaye2(
                         din  = dqs_ser,
                         dout = dqs_dly,
-                        rst  = self.get_rst(it, _l[prefix+'wdly_dqs_rst'], prefix),
-                        inc  = self.get_inc(it, _l[prefix+'wdly_dqs_inc'], prefix),
+                        rst  = self.get_rst(it, _l[prefix+'wdly_dqs_rst'], prefix, "sys2x"),
+                        inc  = self.get_inc(it, _l[prefix+'wdly_dqs_inc'], prefix, "sys2x"),
                         clk="sys2x_unbuf",
                     )
 
@@ -249,8 +249,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.idelaye2(
                     din  = dqs_i,
                     dout = dqs_i_dly,
-                    rst  = self.get_rst(it, _l[prefix+'rdly_dqs_rst'], prefix),
-                    inc  = self.get_inc(it, _l[prefix+'rdly_dqs_inc'], prefix),
+                    rst  = self.get_rst(it, _l[prefix+'rdly_dqs_rst'], prefix, "sys2x"),
+                    inc  = self.get_inc(it, _l[prefix+'rdly_dqs_inc'], prefix, "sys2x"),
                     clk="sys2x_unbuf",
                 )
                 self.iserdese2_ddr(
@@ -271,7 +271,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.comb += out_dq.eq(Cat(delay_dq[:-1], basephy_dq[0]))
                 cdc_out_dq = Signal(len(out_dq)//2)
                 simple_cdc = SimpleCDC(
-                    clkdiv="sys", clk="sys2x_unbuf",
+                    clkdiv="sys", clk="sys2x",
                     i_dw=len(out_dq), o_dw=len(cdc_out_dq),
                     i=out_dq, o=cdc_out_dq,
                     name=f"{prefix}dq_o_{it}",
@@ -287,7 +287,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                     self.comb += out_dq_oe.eq(Cat(delay_dq_oe[:-1], basephy_dq_oe[0]))
                     cdc_out_dq_oe = Signal(len(out_dq_oe)//2)
                     simple_cdc = SimpleCDC(
-                        clkdiv="sys", clk="sys2x_unbuf",
+                        clkdiv="sys", clk="sys2x",
                         i_dw=len(out_dq_oe), o_dw=len(cdc_out_dq_oe),
                         i=out_dq_oe, o=cdc_out_dq_oe,
                         name=f"{prefix}dq_oe{it//modules}",
@@ -313,8 +313,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                     self.odelaye2(
                         din  = dq_ser,
                         dout = dq_dly,
-                        rst  = self.get_rst(it, _l[prefix+'wdly_dq_rst'], prefix),
-                        inc  = self.get_inc(it, _l[prefix+'wdly_dq_inc'], prefix),
+                        rst  = self.get_rst(it, _l[prefix+'wdly_dq_rst'], prefix, "sys2x"),
+                        inc  = self.get_inc(it, _l[prefix+'wdly_dq_inc'], prefix, "sys2x"),
                         clk="sys2x_unbuf",
                     )
                 self.iobuf(
@@ -331,8 +331,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                 self.idelaye2(
                     din  = dq_i,
                     dout = dq_i_dly,
-                    rst  = self.get_rst(it, _l[prefix+'rdly_dq_rst'], prefix),
-                    inc  = self.get_inc(it, _l[prefix+'rdly_dq_inc'], prefix),
+                    rst  = self.get_rst(it, _l[prefix+'rdly_dq_rst'], prefix, "sys2x"),
+                    inc  = self.get_inc(it, _l[prefix+'rdly_dq_inc'], prefix, "sys2x"),
                     clk="sys2x_unbuf",
                 )
                 self.iserdese2_ddr(
@@ -354,7 +354,7 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                     self.comb += out_dm.eq(Cat(delay_dm[:-1], basephy_dm[0]))
                     cdc_out_dm = Signal(len(out_dm)//2)
                     simple_cdc = SimpleCDC(
-                        clkdiv="sys", clk="sys2x_unbuf",
+                        clkdiv="sys", clk="sys2x",
                         i_dw=len(out_dm), o_dw=len(cdc_out_dm),
                         i=out_dm, o=cdc_out_dm,
                         name=f"{prefix}dm_o_{it}",
@@ -376,8 +376,8 @@ class S7DDR5PHY(DDR5PHY, S7Common):
                         self.odelaye2(
                             din  = dmi_ser,
                             dout = dmi_dly,
-                            rst  = self.get_rst(it, _l[preifx+'wdly_dq_rst'], prefix),
-                            inc  = self.get_inc(it, _l[prefix+'wdly_dq_inc'], prefix),
+                            rst  = self.get_rst(it, _l[preifx+'wdly_dq_rst'], prefix, "sys2x"),
+                            inc  = self.get_inc(it, _l[prefix+'wdly_dq_inc'], prefix, "sys2x"),
                             clk="sys2x_unbuf",
                         )
                     self.iobuf(

--- a/litedram/phy/ddr5/s7phy.py
+++ b/litedram/phy/ddr5/s7phy.py
@@ -38,18 +38,6 @@ class S7DDR5PHY(DDR5PHY, S7Common):
         self.settings.write_dq_dqs_training = True
         self.settings.read_leveling = True
 
-        # Parameters -------------------------------------------------------------------------------
-        # Calculate value of taps needed to shift a signal by 90 degrees.
-        # Using iodelay_clk_freq of 300MHz/400MHz is only valid for -3 and -2/2E speed grades.
-        # Note: this should be named sys16x, but using sys8x due to a name hard-coded in BIOS
-        assert iodelay_clk_freq in [200e6, 300e6, 400e6]
-        iodelay_tap_average = 1 / (2*32 * iodelay_clk_freq)
-        half_sys4x_taps = math.floor(self.tck / (4 * iodelay_tap_average))
-        assert half_sys4x_taps < 32, "Exceeded ODELAYE2 max value: {} >= 32".format(half_sys4x_taps)
-
-        # Registers --------------------------------------------------------------------------------
-        self._half_sys8x_taps = CSRStorage(5, reset=half_sys4x_taps)
-
         # delay control
         self._rdly_dq_rst  = CSR()
         self._rdly_dq_inc  = CSR()

--- a/litedram/phy/ddr5/simphy.py
+++ b/litedram/phy/ddr5/simphy.py
@@ -166,9 +166,9 @@ class DDR5SimPHY(SimSerDesMixin, DDR5PHY):
             self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
                      o=getattr(self.pads, prefix+'dqs_c_oe'),
                      name=f'{prefix}dqs_c_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dm_n_oe')[0],
+            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
                      o=getattr(self.pads, prefix+'dm_n_oe'),
                      name=f'{prefix}dm_n_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dq_oe')[0],
+            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
                      o=getattr(self.pads, prefix+'dq_oe'),
                      name=f'{prefix}dq_oe', **ddr)

--- a/litedram/phy/ddr5/simphy.py
+++ b/litedram/phy/ddr5/simphy.py
@@ -8,9 +8,9 @@ from migen import *
 
 from litex.soc.interconnect.csr import CSR
 
-from litedram.phy.utils import delayed, Serializer, Deserializer, Latency
+from litedram.phy.utils import delayed, Serializer, Deserializer, Latency, SimpleCDC
 from litedram.phy.sim_utils import SimPad, SimulationPads, SimSerDesMixin
-from litedram.phy.ddr5.basephy import DDR5PHY
+from litedram.phy.ddr5.basephy import DDR5PHY, DDR5Output
 
 
 class DDR5SimulationPads(SimulationPads):
@@ -60,7 +60,7 @@ class DDR5SimPHY(SimSerDesMixin, DDR5PHY):
 
         self.submodules += pads
         super().__init__(pads,
-            ser_latency       = Latency(sys=Serializer.LATENCY),
+            ser_latency       = Latency(sys2x=Serializer.LATENCY),
             des_latency       = Latency(sys=(Deserializer.LATENCY-1 if aligned_reset_zero else Deserializer.LATENCY)),
             phytype           = "DDR5SimPHY",
             with_sub_channels = with_sub_channels,
@@ -90,85 +90,201 @@ class DDR5SimPHY(SimSerDesMixin, DDR5PHY):
         channels_prefix = [""] if not with_sub_channels else ["A_", "B_"]
         delay = lambda sig, cycles: delayed(self, sig, cycles=cycles)
 
-        sdr     = dict(clkdiv="sys", clk="sys4x")
-        sdr_90  = dict(clkdiv="sys", clk="sys4x_90")
-        cs      = dict(clkdiv="sys", clk="sys4x_180")
-        cmd     = dict(clkdiv="sys", clk="sys4x_180s_ddr")
-        ddr     = dict(clkdiv="sys", clk="sys4x_ddr")
-        ddr_90  = dict(clkdiv="sys", clk="sys4x_90_ddr")
+        cs      = dict(clkdiv="sys2x", clk="sys4x_180", xilinx=True)
+        cmd     = dict(clkdiv="sys2x", clk="sys4x_90_ddr", xilinx=True)
+        ddr     = dict(clkdiv="sys2x", clk="sys4x_ddr", xilinx=True)
+        ddr_90  = dict(clkdiv="sys2x", clk="sys4x_90_ddr", xilinx=True)
 
+        # This configuration mimics Xilinx 7-series serdes behavior
         if aligned_reset_zero:
-            sdr["reset_cnt"] = 0
-            sdr_90["reset_cnt"] = 0
-            cs["reset_cnt"] = 0
-            cmd["reset_cnt"] = 0
             ddr["reset_cnt"] = 0
             ddr["aligned"] = True
-            ddr_90["reset_cnt"] = 0
 
         # Clock is shifted 180 degrees to get rising edge in the middle of SDR signals.
         # To achieve that we send negated clock on clk (clk_p).
         self.ser(i=self.out.ck_t, o=self.pads.ck_t, name='ck_t', **ddr)
         self.ser(i=self.out.ck_c, o=self.pads.ck_c, name='ck_c', **ddr)
 
-        self.ser(i=self.out.reset_n, o=self.pads.reset_n, name='reset_n', **sdr)
-        self.des(i=self.pads.alert_n, o=self.out.alert_n, name='alert_n', **sdr_90)
+        self.ser(i=self.out.reset_n, o=self.pads.reset_n, name='reset_n', **ddr)
+        self.des(i=self.pads.alert_n, o=self.out.alert_n, name='alert_n', **ddr_90)
 
         prefixes = [""] if not with_sub_channels else ["A_", "B_"]
 
         for prefix in prefixes:
 
             # Command/address
-            for rank in range(nranks):
-                self.ser(i=getattr(self.out, prefix+'cs_n')[rank],
-                         o=getattr(self.pads, prefix+'cs_n')[rank],
-                         name=f'{prefix}cs_n', **cs)
-            for i in range(14):
-                self.ser(i=getattr(self.out, prefix+'ca')[i],
-                         o=getattr(self.pads, prefix+'ca')[i],
-                         name=f'{prefix}ca{i}', **cmd)
-            self.ser(i=getattr(self.out, prefix+'par'),
-                     o=getattr(self.pads, prefix+'par'),
-                     name=f'{prefix}par', **cmd)
+            for it, (basephy_cs, pad) in enumerate(zip(getattr(self.out, prefix+'cs_n'), getattr(self.pads, prefix+'cs_n'))):
+                delay_out = Signal.like(basephy_cs)
+                self.sync += delay_out.eq(basephy_cs)
+                cdc_out = Signal(len(delay_out)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(delay_out), o_dw=len(cdc_out),
+                    i=delay_out, o=cdc_out,
+                    name=f"{prefix}cs_n_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_out, o=pad, name=f'{prefix}cs_n_{it}', **cs)
+
+            for it, (basephy_ca, pad) in enumerate(zip(getattr(self.out, prefix+'ca'), getattr(self.pads, prefix+'ca'))):
+                delay_ca = Signal()
+                out_ca = Signal.like(basephy_ca)
+                self.sync += delay_ca.eq(basephy_ca[-1])
+                self.sync += out_ca.eq(Cat(delay_ca, basephy_ca[0:-1]))
+                cdc_out_ca = Signal(len(out_ca)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(out_ca), o_dw=len(cdc_out_ca),
+                    i=out_ca, o=cdc_out_ca,
+                    name=f"{prefix}ca_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_out_ca, o=pad, name=f'{prefix}ca{it}', **cmd)
+
+            basephy_par = getattr(self.out, prefix+'par')
+            pad = getattr(self.pads, prefix+'par')
+
+            delay_par = Signal()
+            out_par = Signal.like(basephy_par)
+            self.sync += delay_par.eq(basephy_par[-1])
+            self.sync += out_par.eq(Cat(delay_par, basephy_par[0:-1]))
+            cdc_out_par = Signal(len(basephy_par)//2)
+            simple_cdc = SimpleCDC(
+                clkdiv="sys", clk="sys2x",
+                i_dw=len(out_par), o_dw=len(cdc_out_par),
+                i=out_par, o=cdc_out_par,
+                name=f"{prefix}par_{it}"
+            )
+            self.submodules += simple_cdc
+            self.ser(i=cdc_out_par, o=pad, name=f'{prefix}par', **cmd)
 
             # Tristate I/O (separate for simulation)
-            for i in range(self.databits//dq_dqs_ratio):
-                self.ser(i=getattr(self.out, prefix+'dqs_t_o')[i],
-                         o=getattr(self.pads, prefix+'dqs_t_o')[i],
-                         name=f'{prefix}dqs_t_o{i}', **ddr)
-                self.des(o=getattr(self.out, prefix+'dqs_t_i')[i],
-                         i=getattr(self.pads, prefix+'dqs_t')[i],
-                         name=f'{prefix}dqs_t_i{i}', **ddr)
-                self.ser(i=getattr(self.out, prefix+'dqs_c_o')[i],
-                         o=getattr(self.pads, prefix+'dqs_c_o')[i],
-                         name=f'{prefix}dqs_c_o{i}', **ddr)
-                self.des(o=getattr(self.out, prefix+'dqs_c_i')[i],
-                         i=getattr(self.pads, prefix+'dqs_c')[i],
-                         name=f'{prefix}dqs_c_i{i}', **ddr)
-                self.ser(i=getattr(self.out, prefix+'dm_n_o')[i],
-                         o=getattr(self.pads, prefix+'dm_n_o')[i],
-                         name=f'{prefix}dm_n_o{i}', **ddr_90)
-                self.des(o=getattr(self.out, prefix+'dm_n_i')[i],
-                         i=getattr(self.pads, prefix+'dm_n')[i],
-                         name=f'{prefix}dm_n_i{i}', **ddr_90)
-            for i in range(self.databits):
-                self.ser(i=getattr(self.out, prefix+'dq_o')[i],
-                         o=getattr(self.pads, prefix+'dq_o')[i],
-                         name=f'{prefix}dq_o{i}', **ddr_90)
-                self.des(o=getattr(self.out, prefix+'dq_i')[i],
-                         i=getattr(self.pads, prefix+'dq')[i],
-                         name=f'{prefix}dq_i{i}', **ddr_90)
+            for it in range(self.databits//dq_dqs_ratio):
+                dqs_t_o = getattr(self.out, prefix+'dqs_t_o')[it]
+                cdc_dqs_t_o = Signal(len(dqs_t_o)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(dqs_t_o), o_dw=len(cdc_dqs_t_o),
+                    i=dqs_t_o, o=cdc_dqs_t_o,
+                    name=f"{prefix}dqs_t_o_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_dqs_t_o,
+                         o=getattr(self.pads, prefix+'dqs_t_o')[it],
+                         name=f'{prefix}dqs_t_o{it}', **ddr)
+                self.des(o=getattr(self.out, prefix+'dqs_t_i')[it],
+                         i=getattr(self.pads, prefix+'dqs_t')[it],
+                         name=f'{prefix}dqs_t_i{it}', **ddr)
+
+                dqs_c_o = getattr(self.out, prefix+'dqs_c_o')[it]
+                cdc_dqs_c_o = Signal(len(dqs_c_o)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(dqs_c_o), o_dw=len(cdc_dqs_c_o),
+                    i=dqs_c_o, o=cdc_dqs_c_o,
+                    name=f"{prefix}dqs_c_o_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_dqs_c_o,
+                         o=getattr(self.pads, prefix+'dqs_c_o')[it],
+                         name=f'{prefix}dqs_c_o{it}', **ddr)
+                self.des(o=getattr(self.out, prefix+'dqs_c_i')[it],
+                         i=getattr(self.pads, prefix+'dqs_c')[it],
+                         name=f'{prefix}dqs_c_i{it}', **ddr)
+
+                basephy_dm = getattr(self.out, prefix+'dm_n_o')[it]
+                delay_dm = Signal.like(basephy_dm)
+                out_dm = Signal.like(basephy_dm)
+                self.sync += delay_dm.eq(basephy_dm[1:])
+                self.comb += out_dm.eq(Cat(delay_dm[:-1], basephy_dm[0]))
+                cdc_out_dm = Signal(len(out_dm)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(out_dm), o_dw=len(cdc_out_dm),
+                    i=out_dm, o=cdc_out_dm,
+                    name=f"{prefix}dm_o_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_out_dm, o=getattr(self.pads, prefix+'dm_n_o')[it],
+                         name=f'{prefix}dm_n_o{it}', **ddr_90)
+
+                basephy_dm_i =  getattr(self.out, prefix+'dm_n_i')[it]
+                in_dm = Signal.like(basephy_dm_i)
+                self.des(o=in_dm, i=getattr(self.pads, prefix+'dm_n')[it],
+                         name=f'{prefix}dm_n_i{it}', **ddr_90)
+                delay_dm_i = Signal(2)
+                self.sync += delay_dm_i.eq(in_dm[-2:])
+                self.comb += basephy_dm_i.eq(Cat(delay_dm_i, in_dm[:-2]))
+
+            for it in range(self.databits):
+                basephy_dq = getattr(self.out, prefix+'dq_o')[it]
+                delay_dq = Signal.like(basephy_dq)
+                out_dq = Signal.like(basephy_dq)
+                self.sync += delay_dq.eq(basephy_dq[1:])
+                self.comb += out_dq.eq(Cat(delay_dq[:-1], basephy_dq[0]))
+                cdc_out_dq = Signal(len(out_dq)//2)
+                simple_cdc = SimpleCDC(
+                    clkdiv="sys", clk="sys2x",
+                    i_dw=len(out_dq), o_dw=len(cdc_out_dq),
+                    i=out_dq, o=cdc_out_dq,
+                    name=f"{prefix}dq_o_{it}"
+                )
+                self.submodules += simple_cdc
+                self.ser(i=cdc_out_dq, o=getattr(self.pads, prefix+'dq_o')[it],
+                         name=f'{prefix}dq_o{it}', **ddr_90)
+
+                basephy_dq_i =  getattr(self.out, prefix+'dq_i')[it]
+                in_dq = Signal.like(basephy_dq_i)
+                self.des(o=in_dq, i=getattr(self.pads, prefix+'dq')[it],
+                         name=f'{prefix}dq_i{it}', reset_cnt=-2, **ddr_90)
+                delay_dq_i = Signal(2)
+                self.sync += delay_dq_i.eq(in_dq[-2:])
+                self.comb += basephy_dq_i.eq(Cat(delay_dq_i, in_dq[:-2]))
 
             # Output enable signals can be and should be serialized as well
-            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
+            out_dqs_t_oe = getattr(self.out, prefix+'dqs_oe')[0]
+            cdc_out_dqs_t_oe = Signal(len(out_dqs_t_oe)//2)
+            simple_cdc = SimpleCDC(
+                clkdiv="sys", clk="sys2x",
+                i_dw=len(out_dqs_t_oe), o_dw=len(cdc_out_dqs_t_oe),
+                i=out_dqs_t_oe, o=cdc_out_dqs_t_oe,
+                name=f"{prefix}dqs_t_oe"
+            )
+            self.submodules += simple_cdc
+            self.ser(i=cdc_out_dqs_t_oe,
                      o=getattr(self.pads, prefix+'dqs_t_oe'),
                      name=f'{prefix}dqs_t_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
+            out_dqs_c_oe = getattr(self.out, prefix+'dqs_oe')[0]
+            cdc_out_dqs_c_oe = Signal(len(out_dqs_c_oe)//2)
+            simple_cdc = SimpleCDC(
+                clkdiv="sys", clk="sys2x",
+                i_dw=len(out_dqs_c_oe), o_dw=len(cdc_out_dqs_c_oe),
+                i=out_dqs_c_oe, o=cdc_out_dqs_c_oe,
+                name=f"{prefix}dqs_c_oe"
+            )
+            self.submodules += simple_cdc
+            self.ser(i=cdc_out_dqs_c_oe,
                      o=getattr(self.pads, prefix+'dqs_c_oe'),
                      name=f'{prefix}dqs_c_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
-                     o=getattr(self.pads, prefix+'dm_n_oe'),
-                     name=f'{prefix}dm_n_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
+
+            basephy_dq_oe = getattr(self.out, prefix+'dq_oe')[0]
+            delay_dq_oe = Signal.like(basephy_dq_oe)
+            out_dq_oe = Signal.like(basephy_dq_oe)
+            self.sync += delay_dq_oe.eq(basephy_dq_oe[1:])
+            self.comb += out_dq_oe.eq(Cat(delay_dq_oe[:-1], basephy_dq_oe[0]))
+            out_dqs_c_oe = getattr(self.out, prefix+'dqs_oe')[0]
+            cdc_out_dq_oe = Signal(len(out_dq_oe)//2)
+            simple_cdc = SimpleCDC(
+                clkdiv="sys", clk="sys2x",
+                i_dw=len(out_dq_oe), o_dw=len(cdc_out_dq_oe),
+                i=out_dq_oe, o=cdc_out_dq_oe,
+                name=f"{prefix}dq_oe"
+            )
+            self.submodules += simple_cdc
+            self.ser(i=cdc_out_dq_oe,
                      o=getattr(self.pads, prefix+'dq_oe'),
-                     name=f'{prefix}dq_oe', **ddr)
+                     name=f'{prefix}dq_oe', **ddr_90)
+
+            self.ser(i=cdc_out_dq_oe,
+                     o=getattr(self.pads, prefix+'dm_n_oe'),
+                     name=f'{prefix}dm_n_oe', **ddr_90)

--- a/litedram/phy/ddr5/simphy.py
+++ b/litedram/phy/ddr5/simphy.py
@@ -160,15 +160,15 @@ class DDR5SimPHY(SimSerDesMixin, DDR5PHY):
                          name=f'{prefix}dq_i{i}', **ddr_90)
 
             # Output enable signals can be and should be serialized as well
-            self.ser(i=getattr(self.out, prefix+'dqs_oe'),
+            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
                      o=getattr(self.pads, prefix+'dqs_t_oe'),
                      name=f'{prefix}dqs_t_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe'),
+            self.ser(i=getattr(self.out, prefix+'dqs_oe')[0],
                      o=getattr(self.pads, prefix+'dqs_c_oe'),
                      name=f'{prefix}dqs_c_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe'),
+            self.ser(i=getattr(self.out, prefix+'dm_n_oe')[0],
                      o=getattr(self.pads, prefix+'dm_n_oe'),
                      name=f'{prefix}dm_n_oe', **ddr)
-            self.ser(i=getattr(self.out, prefix+'dqs_oe'),
+            self.ser(i=getattr(self.out, prefix+'dq_oe')[0],
                      o=getattr(self.pads, prefix+'dq_oe'),
                      name=f'{prefix}dq_oe', **ddr)

--- a/litedram/phy/ddr5/simsoc.py
+++ b/litedram/phy/ddr5/simsoc.py
@@ -140,15 +140,17 @@ _io = {
 # Clocks -------------------------------------------------------------------------------------------
 
 def get_clocks(sys_clk_freq):
-    return Clocks({
-        "sys":           dict(freq_hz=sys_clk_freq),
-        "sys4x":         dict(freq_hz=4*sys_clk_freq),
-        "sys4x_ddr":     dict(freq_hz=2*4*sys_clk_freq),
-        "sys4x_90":      dict(freq_hz=4*sys_clk_freq, phase_deg=90),
-        "sys4x_180":     dict(freq_hz=4*sys_clk_freq, phase_deg=180),
-        "sys4x_90_ddr":  dict(freq_hz=2*4*sys_clk_freq, phase_deg=2*90),
-        "sys4x_180s_ddr":  dict(freq_hz=2*4*sys_clk_freq, phase_deg=90),
-    })
+    clk_dict = {
+        "sys":             dict(freq_hz=sys_clk_freq),
+        "sys2x":           dict(freq_hz=2*sys_clk_freq),
+        "sys4x":           dict(freq_hz=4*sys_clk_freq),
+        "sys4x_ddr":       dict(freq_hz=2*4*sys_clk_freq),                  # RCD cmd sample
+        "sys4x_180":       dict(freq_hz=4*sys_clk_freq, phase_deg=180),     # phy cs
+        "sys4x_180_ddr":   dict(freq_hz=2*4*sys_clk_freq),                  # phy ca
+        "sys4x_90":        dict(freq_hz=4*sys_clk_freq, phase_deg=90),      # phy oe delay
+        "sys4x_90_ddr":    dict(freq_hz=2*4*sys_clk_freq, phase_deg=2*90),  # phy dq/dqs IO
+    }
+    return Clocks(clk_dict)
 
 # SoC ----------------------------------------------------------------------------------------------
 

--- a/litedram/phy/dfi.py
+++ b/litedram/phy/dfi.py
@@ -46,7 +46,7 @@ def phase_wrdata_description(databits, with_sub_channels=False):
         temp.append((prefix, [
             ("wrdata",     databits//_l, DIR_M_TO_S),
             ("wrdata_en",             1, DIR_M_TO_S),
-            ("wrdata_mask", databits//8, DIR_M_TO_S)]))
+            ("wrdata_mask", databits//8 if not with_sub_channels else databits//16, DIR_M_TO_S)]))
     return temp[0][1] if not with_sub_channels else temp
 
 

--- a/litedram/phy/s7common.py
+++ b/litedram/phy/s7common.py
@@ -65,11 +65,12 @@ class S7Common(Module):
 
         self.specials += Instance("ODELAYE2", **params)
 
-    def oserdese2_ddr_with_tri(self, *, din, clk, tin, tout, dout=None, dout_fb=None, clkdiv="sys2x"):
+    def oserdese2_ddr_with_tri(self, *, din, clk, tin, tout, dout=None, dout_fb=None, clkdiv="sys2x", rst_sig=None):
         data_width = len(din)
         assert data_width == 4, (data_width, din)
         assert not ((dout is None) and (dout_fb is None)), "Output to OQ (-> IOB) and/or to OFB (-> ISERDESE2/ODELAYE2)"
 
+        rst_sig = self._rst.storage if rst_sig is None else rst_sig
         dout = Signal() if dout is None else dout
         dout_fb = Signal() if dout_fb is None else dout_fb
 
@@ -79,7 +80,7 @@ class S7Common(Module):
             p_TRISTATE_WIDTH = 4,
             p_DATA_RATE_OQ   = "DDR",
             p_DATA_RATE_TQ   = "DDR",
-            i_RST    = ResetSignal() | self._rst.storage,
+            i_RST    = ResetSignal(clkdiv) | rst_sig,
             i_CLK    = ClockSignal(clk),
             i_CLKDIV = ClockSignal(clkdiv),
             o_TQ     = tout,
@@ -95,12 +96,14 @@ class S7Common(Module):
 
         self.specials += Instance("OSERDESE2", **params)
 
-    def oserdese2_ddr(self, *, din, clk, dout=None, dout_fb=None, tin=None, tout=None, clkdiv="sys2x", invert_clk=False):
+    def oserdese2_ddr(self, *, din, clk, dout=None, dout_fb=None, tin=None, tout=None,
+                      clkdiv="sys2x", invert_clk=False, rst_sig=None):
         data_width = len(din)
         assert data_width in [4, 8], (data_width, din)
         assert not ((tin is None) ^ (tout is None)), "When using tristate specify both `tin` and `tout`"
         assert not ((dout is None) and (dout_fb is None)), "Output to OQ (-> IOB) and/or to OFB (-> ISERDESE2/ODELAYE2)"
 
+        rst_sig = self._rst.storage if rst_sig is None else rst_sig
         dout = Signal() if dout is None else dout
         dout_fb = Signal() if dout_fb is None else dout_fb
 
@@ -110,7 +113,7 @@ class S7Common(Module):
             p_TRISTATE_WIDTH = 1,
             p_DATA_RATE_OQ   = "DDR",
             p_DATA_RATE_TQ   = "BUF",
-            i_RST    = ResetSignal() | self._rst.storage,
+            i_RST    = ResetSignal(clkdiv) | rst_sig,
             i_CLK    = ClockSignal(clk),
             i_CLKDIV = ClockSignal(clkdiv),
             o_OQ     = dout,
@@ -138,10 +141,11 @@ class S7Common(Module):
         self.comb += din_ddr.eq(Cat(*[Replicate(bit, ratio) for bit in din]))
         self.oserdese2_ddr(**kwargs)
 
-    def iserdese2_ddr(self, *, din, dout, clk, clkdiv="sys2x"):
+    def iserdese2_ddr(self, *, din, dout, clk, clkdiv="sys2x", rst_sig=None):
         data_width = len(dout)
         assert data_width == 8, (data_width, dout)
 
+        rst_sig = self._rst.storage if rst_sig is None else rst_sig
         params = dict(
             p_SERDES_MODE    = "MASTER",
             p_INTERFACE_TYPE = "NETWORKING",
@@ -149,7 +153,7 @@ class S7Common(Module):
             p_DATA_RATE      = "DDR",
             p_NUM_CE         = 1,
             p_IOBDELAY       = "IFD",
-            i_RST     = ResetSignal() | self._rst.storage,
+            i_RST     = ResetSignal(clkdiv) | rst_sig,
             i_CLK     = ClockSignal(clk),
             i_CLKB    = ~ClockSignal(clk),
             i_CLKDIV  = ClockSignal(clkdiv),

--- a/litedram/phy/s7ddrphy.py
+++ b/litedram/phy/s7ddrphy.py
@@ -400,11 +400,11 @@ class S7DDRPHY(Module, AutoCSR):
         self.comb += dq_oe_delay.input.eq(dqs_preamble | dq_oe | dqs_postamble)
 
         for i in range(databits):
-            __temp = Signal()
+            __dq_sel = Signal()
             if with_per_dq_idelay:
-                self.comb += __temp.eq(self._dq_dly_sel.storage[i%dq_dqs_ratio])
+                self.comb += __dq_sel.eq(self._dq_dly_sel.storage[i%dq_dqs_ratio])
             else:
-                self.comb += __temp.eq(1)
+                self.comb += __dq_sel.eq(1)
             dq_o_nodelay = Signal()
             dq_o_delayed = Signal()
             dq_i_nodelay = Signal()
@@ -413,8 +413,8 @@ class S7DDRPHY(Module, AutoCSR):
             dq_i_data    = Signal(8)
             dq_o_bitslip = BitSlip(8,
                 i      = Cat(*[dfi.phases[n//2].wrdata[n%2*databits+i] for n in range(8)]),
-                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & wdly_dq_bitslip_rst) | self._rst.storage,
-                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & wdly_dq_bitslip,
+                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & wdly_dq_bitslip_rst) | self._rst.storage,
+                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & wdly_dq_bitslip,
                 cycles = 1)
             self.submodules += dq_o_bitslip
             self.specials += Instance("OSERDESE2",
@@ -434,8 +434,8 @@ class S7DDRPHY(Module, AutoCSR):
                 o_OQ     = dq_o_nodelay,
             )
             dq_i_bitslip = BitSlip(8,
-                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_bitslip_rst) | self._rst.storage,
-                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_bitslip,
+                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & rdly_dq_bitslip_rst) | self._rst.storage,
+                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & rdly_dq_bitslip,
                 cycles = 1)
             self.submodules += dq_i_bitslip
             self.specials += Instance("ISERDESE2",
@@ -484,10 +484,10 @@ class S7DDRPHY(Module, AutoCSR):
                 p_IDELAY_TYPE           = "VARIABLE",
                 p_IDELAY_VALUE          = 0,
                 i_C        = ClockSignal("sys"),
-                i_LD       = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_rst) |
+                i_LD       = (self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & rdly_dq_rst) |
                               self._rst.storage,
                 i_LDPIPEEN = 0,
-                i_CE       = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_inc,
+                i_CE       = self._dly_sel.storage[i//dq_dqs_ratio] & __dq_sel & rdly_dq_inc,
                 i_INC      = 1,
                 i_IDATAIN  = dq_i_nodelay,
                 o_DATAOUT  = dq_i_delayed

--- a/litedram/phy/s7ddrphy.py
+++ b/litedram/phy/s7ddrphy.py
@@ -38,7 +38,8 @@ class S7DDRPHY(Module, AutoCSR):
         ddr_clk          = None,
         csr_cdc          = None,
         is_rdimm         = False,
-        write_latency_calibration = True):
+        write_latency_calibration = True,
+        with_per_dq_idelay = False):
         assert memtype in ["DDR2", "DDR3", "DDR4"]
         assert not (memtype == "DDR3" and nphases == 2)
         phytype     = self.__class__.__name__
@@ -72,7 +73,13 @@ class S7DDRPHY(Module, AutoCSR):
         # Registers --------------------------------------------------------------------------------
         self._rst             = CSRStorage()
 
+        dq_dqs_ratio = databits // strobes
+        assert (dq_dqs_ratio in [4, 8])
+
         self._dly_sel         = CSRStorage(strobes)
+        if with_per_dq_idelay :
+            self._dq_dly_sel  = CSRStorage(dq_dqs_ratio)
+
         self._half_sys8x_taps = CSRStorage(5, reset=half_sys8x_taps)
 
         self._wlevel_en     = CSRStorage()
@@ -147,6 +154,7 @@ class S7DDRPHY(Module, AutoCSR):
             read_leveling             = True,
             delays                    = 32,
             bitslips                  = 8,
+            with_per_dq_idelay        = with_per_dq_idelay,
         )
 
         if is_rdimm:
@@ -189,6 +197,7 @@ class S7DDRPHY(Module, AutoCSR):
                     o_OQ     = sd_clk_se_nodelay,
                     i_OCE    = 1,
                 )
+
                 if with_odelay:
                    self.specials += Instance("ODELAYE2",
                         p_SIGNAL_PATTERN        = "DATA",
@@ -207,6 +216,7 @@ class S7DDRPHY(Module, AutoCSR):
                         o_ODATAIN  = sd_clk_se_nodelay,
                         o_DATAOUT  = sd_clk_se_delayed,
                     )
+
                 self.specials += Instance("OBUFDS",
                     i_I  = sd_clk_se_delayed if with_odelay else sd_clk_se_nodelay,
                     o_O  = pads.clk_p[i],
@@ -389,10 +399,12 @@ class S7DDRPHY(Module, AutoCSR):
         self.submodules += dq_oe_delay
         self.comb += dq_oe_delay.input.eq(dqs_preamble | dq_oe | dqs_postamble)
 
-        dq_dqs_ratio = databits // strobes
-        assert (dq_dqs_ratio in [4, 8])
-
         for i in range(databits):
+            __temp = Signal()
+            if with_per_dq_idelay:
+                self.comb += __temp.eq(self._dq_dly_sel.storage[i%dq_dqs_ratio])
+            else:
+                self.comb += __temp.eq(1)
             dq_o_nodelay = Signal()
             dq_o_delayed = Signal()
             dq_i_nodelay = Signal()
@@ -401,8 +413,8 @@ class S7DDRPHY(Module, AutoCSR):
             dq_i_data    = Signal(8)
             dq_o_bitslip = BitSlip(8,
                 i      = Cat(*[dfi.phases[n//2].wrdata[n%2*databits+i] for n in range(8)]),
-                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & wdly_dq_bitslip_rst) | self._rst.storage,
-                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & wdly_dq_bitslip,
+                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & wdly_dq_bitslip_rst) | self._rst.storage,
+                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & wdly_dq_bitslip,
                 cycles = 1)
             self.submodules += dq_o_bitslip
             self.specials += Instance("OSERDESE2",
@@ -422,8 +434,8 @@ class S7DDRPHY(Module, AutoCSR):
                 o_OQ     = dq_o_nodelay,
             )
             dq_i_bitslip = BitSlip(8,
-                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & rdly_dq_bitslip_rst) | self._rst.storage,
-                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & rdly_dq_bitslip,
+                rst    = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_bitslip_rst) | self._rst.storage,
+                slp    = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_bitslip,
                 cycles = 1)
             self.submodules += dq_i_bitslip
             self.specials += Instance("ISERDESE2",
@@ -472,9 +484,10 @@ class S7DDRPHY(Module, AutoCSR):
                 p_IDELAY_TYPE           = "VARIABLE",
                 p_IDELAY_VALUE          = 0,
                 i_C        = ClockSignal("sys"),
-                i_LD       = (self._dly_sel.storage[i//dq_dqs_ratio] & rdly_dq_rst) | self._rst.storage,
+                i_LD       = (self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_rst) |
+                              self._rst.storage,
                 i_LDPIPEEN = 0,
-                i_CE       = self._dly_sel.storage[i//dq_dqs_ratio] & rdly_dq_inc,
+                i_CE       = self._dly_sel.storage[i//dq_dqs_ratio] & __temp & rdly_dq_inc,
                 i_INC      = 1,
                 i_IDATAIN  = dq_i_nodelay,
                 o_DATAOUT  = dq_i_delayed

--- a/litedram/phy/utils.py
+++ b/litedram/phy/utils.py
@@ -228,7 +228,7 @@ class Serializer(Module):
 
     LATENCY = 1
 
-    def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, reset=None, reset_cnt=-1, name=None):
+    def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, reset=None, reset_cnt=-1, name=None, aligned=False):
         assert i_dw > o_dw, (i_dw, o_dw)
         assert i_dw % o_dw == 0, (i_dw, o_dw)
         ratio = i_dw // o_dw
@@ -262,7 +262,7 @@ class Serializer(Module):
         )
 
         # Parallel part
-        sd_clkdiv += i_d[~cnt[0]].eq(i)
+        sd_clkdiv += i_d[~cnt[0]].eq(i) if not aligned else i_d[cnt[0]].eq(i)
 
         self.i_array = i_array = Array([i_d[n%2][n//2*o_dw:(n//2+1)*o_dw] for n in range(2 * ratio)])
         self.comb += self.o.eq(i_array[cnt])
@@ -281,7 +281,7 @@ class Deserializer(Module):
     """
     LATENCY = 2
 
-    def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, reset=None, reset_cnt=-1, name=None):
+    def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, reset=None, reset_cnt=-1, name=None, aligned=False):
         assert i_dw < o_dw, (i_dw, o_dw)
         assert o_dw % i_dw == 0, (i_dw, o_dw)
         ratio = o_dw // i_dw

--- a/litedram/phy/utils.py
+++ b/litedram/phy/utils.py
@@ -216,7 +216,7 @@ class CommandsPipeline(Module):
 
 
 class SimpleCDC(Module):
-   def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, name=None):
+   def __init__(self, clkdiv, clk, i_dw, o_dw, i=None, o=None, name=None, register=False):
         assert i_dw == o_dw*2, (i_dw, o_dw)
 
         sd_clk = getattr(self.sync, clk)
@@ -224,7 +224,10 @@ class SimpleCDC(Module):
 
         if i is None: i = Signal(i_dw)
         if o is None: o = Signal(o_dw)
+        self.i = i
+        self.o = o
         reset_n = Signal(name='{}_reset_n'.format(name) if name is not None else None)
+        reset_n.attr.add("keep")
         w_cnt = Signal(name='{}_w_cnt'.format(name) if name is not None else None)
         r_ready = Signal(name='{}_r_ready'.format(name) if name is not None else None)
         r_row_cnt = Signal(name='{}_r_row_cnt'.format(name) if name is not None else None)
@@ -258,7 +261,11 @@ class SimpleCDC(Module):
             Array([i_d[1][0:o_dw], i_d[1][o_dw:]])
         ])
 
-        self.comb += If(r_ready, o.eq(o_array[r_row_cnt][r_col_cnt]))
+        if not register:
+            self.comb += If(r_ready, o.eq(o_array[r_row_cnt][r_col_cnt]))
+        else:
+            self.LATENCY=4
+            sd_clk += If(r_ready, o.eq(o_array[r_row_cnt][r_col_cnt]))
 
 
 class Serializer(Module):

--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -76,7 +76,7 @@ class DDR5Tests(unittest.TestCase):
         self.dqs_t_rd_latency: str = self.xs * 2 + (self.read_latency - 2 - 1) * self.xs + 'x' * (self.NPHASES - 1) * 2
         self.dq_rd_latency:    str = self.xs * 2 + (self.read_latency - 2) * self.zeros  + '0' * (self.NPHASES - 1) * 2
         self.dqs_t_wr_latency: str = self.xs * 2 + (self.cmd_latency + self.write_latency - 1) * self.xs + 'x' * (self.NPHASES - 1) * 2
-        self.dq_wr_latency:    str = self.xs * 2 + (self.cmd_latency + self.write_latency) * self.zeros  + '0' * (self.NPHASES - 1) * 2
+        self.dq_wr_latency:    str = self.xs * 2 + (self.cmd_latency + self.write_latency) * self.zeros  + 'x' * (self.NPHASES - 1) * 2
 
     @staticmethod
     def process_ca(ca: str) -> int:
@@ -158,7 +158,7 @@ class DDR5Tests(unittest.TestCase):
                 {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
             ],
             pad_checkers = {"sys4x_90_ddr": {
-                'ck_t': self.xs * 2 + '10101010' * (self.cmd_latency + 1),
+                'ck_t': self.xs * 3 + '10101010' * (self.cmd_latency),
             }},
             vcd_name="ddr5_clk.vcd"
         )


### PR DESCRIPTION
Requires https://github.com/antmicro/litedram/pull/49
Updates S7PHY to new BasePHY and adds support for tristate serialization.