### PR TITLE
DDR5 RCD 01 simulation model

### DIFF
--- a/litedram/DDR5RCD01/DDR5GlueRCD.py
+++ b/litedram/DDR5RCD01/DDR5GlueRCD.py
@@ -1,0 +1,117 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.DDR5RCD01CoreIngressSimulationPads import DDR5RCD01CoreIngressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01DataBufferSimulationPads import DDR5RCD01DataBufferSimulationPads
+
+
+
+class DDR5GlueRCD(Module):
+    """ Glue logic between DDR5 Sim Pads and RCD Sim Pads
+    TODO Documentation
+    """
+
+    def __init__(self, pads_ddr5, with_sub_channels=False, **kwargs):
+        # TODO implementation
+        # For signals in pads_ddr5
+        # Split signals into Core and Data Pads
+
+        # Connect simPHY to RCD
+        self.pi = DDR5RCD01CoreIngressSimulationPads()
+
+        connection_matrix_sc = {
+            'dck_t': ['ck_t', 'Forward'],
+            'dck_c': ['ck_c', 'Forward'],
+            'drst_n': ['reset_n', 'Forward'],
+            'alert_n': ['alert_n', 'Reverse'],
+        }
+        for key in connection_matrix_sc:
+            sig_eg = key
+            sig_in = connection_matrix_sc[key][0]
+            # Get attr in egress
+            atr_eg = getattr(self.pi, sig_eg)
+            # Get attr in ingress
+            atr_in = getattr(pads_ddr5, sig_in)
+            # Determine correct direction
+            direction = connection_matrix_sc[key][1]
+            if direction == 'Forward':
+                print('Connect : ' + sig_in + ' to ' + sig_eg)
+                self.comb += atr_eg.eq(atr_in)
+                pass
+            elif direction == 'Reverse':
+                print('Connect : ' + sig_eg + ' to ' + sig_in)
+                self.comb += atr_in.eq(atr_eg)
+                pass
+            else:
+                raise (
+                    'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+        # TODO check polarity of CA
+        prefixes = [""] if not with_sub_channels else ["A_", "B_"]
+        connection_matrix_dc = {
+            'dcs_n': ['cs_n', 'Forward'],
+            'dca': ['ca', 'Forward'],
+            'dpar': ['par', 'Forward'],
+        }
+
+        for prefix in prefixes:
+            for key in connection_matrix_dc:
+                sig_eg = prefix+key
+                sig_in = prefix+connection_matrix_dc[key][0]
+                # Get attr in egress
+                atr_eg = getattr(self.pi, sig_eg)
+                # Get attr in ingress
+                atr_in = getattr(pads_ddr5, sig_in)
+                # Determine correct direction
+                direction = connection_matrix_dc[key][1]
+                if direction == 'Forward':
+                    print('Connect : ' + sig_in + ' to ' + sig_eg)
+                    self.comb += atr_eg.eq(atr_in)
+                    pass
+                elif direction == 'Reverse':
+                    print('Connect : ' + sig_eg + ' to ' + sig_in)
+                    self.comb += atr_in.eq(atr_eg)
+                    pass
+                else:
+                    raise (
+                        'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+        # TODO confirm that dm_n and cb are the same signal
+        self.pdi = DDR5RCD01DataBufferSimulationPads()
+        connection_matrix_db = {
+            'dq': ['dq', 'Forward'],
+            'cb': ['dm_n', 'Forward'],
+            'dqs_t': ['dqs_t', 'Forward'],
+            'dqs_c': ['dqs_c', 'Forward'],
+        }
+        for prefix in prefixes:
+            for key in connection_matrix_db:
+                sig_eg = prefix+key
+                sig_in = prefix+connection_matrix_db[key][0]
+                # Get attr in egress
+                atr_eg = getattr(self.pdi, sig_eg)
+                # Get attr in ingress
+                atr_in = getattr(pads_ddr5, sig_in)
+                # Determine correct direction
+                direction = connection_matrix_db[key][1]
+                if direction == 'Forward':
+                    print('Connect : ' + sig_in + ' to ' + sig_eg)
+                    self.comb += atr_eg.eq(atr_in)
+                    pass
+                elif direction == 'Reverse':
+                    print('Connect : ' + sig_eg + ' to ' + sig_in)
+                    self.comb += atr_in.eq(atr_eg)
+                    pass
+                else:
+                    raise (
+                        'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5GlueRCDData.py
+++ b/litedram/DDR5RCD01/DDR5GlueRCDData.py
@@ -1,0 +1,116 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.DDR5RCD01CoreIngressSimulationPads import DDR5RCD01CoreIngressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01DataBufferSimulationPads import DDR5RCD01DataBufferSimulationPads
+
+
+class DDR5GlueRCDData(Module):
+    """ Glue logic between DDR5 Sim Pads and RCD Sim Pads
+    TODO Documentation
+    """
+
+    def __init__(self, pads_ddr5, with_sub_channels=False, **kwargs):
+        # TODO implementation
+        # For signals in pads_ddr5
+        # Split signals into Core and Data Pads
+
+        # Connect simPHY to RCD
+        self.pi = DDR5RCD01CoreIngressSimulationPads()
+
+        connection_matrix_sc = {
+            'dck_t': ['ck_t', 'Forward'],
+            'dck_c': ['ck_c', 'Forward'],
+            'drst_n': ['reset_n', 'Forward'],
+            'alert_n': ['alert_n', 'Reverse'],
+        }
+        for key in connection_matrix_sc:
+            sig_eg = key
+            sig_in = connection_matrix_sc[key][0]
+            # Get attr in egress
+            atr_eg = getattr(self.pi, sig_eg)
+            # Get attr in ingress
+            atr_in = getattr(pads_ddr5, sig_in)
+            # Determine correct direction
+            direction = connection_matrix_sc[key][1]
+            if direction == 'Forward':
+                print('Connect : ' + sig_in + ' to ' + sig_eg)
+                self.comb += atr_eg.eq(atr_in)
+                pass
+            elif direction == 'Reverse':
+                print('Connect : ' + sig_eg + ' to ' + sig_in)
+                self.comb += atr_in.eq(atr_eg)
+                pass
+            else:
+                raise (
+                    'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+        # TODO check polarity of CA
+        prefixes = [""] if not with_sub_channels else ["A_", "B_"]
+        connection_matrix_dc = {
+            'dcs_n': ['cs_n', 'Forward'],
+            'dca': ['ca', 'Forward'],
+            'dpar': ['par', 'Forward'],
+        }
+
+        for prefix in prefixes:
+            for key in connection_matrix_dc:
+                sig_eg = prefix+key
+                sig_in = prefix+connection_matrix_dc[key][0]
+                # Get attr in egress
+                atr_eg = getattr(self.pi, sig_eg)
+                # Get attr in ingress
+                atr_in = getattr(pads_ddr5, sig_in)
+                # Determine correct direction
+                direction = connection_matrix_dc[key][1]
+                if direction == 'Forward':
+                    print('Connect : ' + sig_in + ' to ' + sig_eg)
+                    self.comb += atr_eg.eq(atr_in)
+                    pass
+                elif direction == 'Reverse':
+                    print('Connect : ' + sig_eg + ' to ' + sig_in)
+                    self.comb += atr_in.eq(atr_eg)
+                    pass
+                else:
+                    raise (
+                        'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+        # TODO confirm that dm_n and cb are the same signal
+        self.pdi = DDR5RCD01DataBufferSimulationPads()
+        connection_matrix_db = {
+            'dq': ['dq', 'Forward'],
+            'cb': ['dm_n', 'Forward'],
+            'dqs_t': ['dqs_t', 'Forward'],
+            'dqs_c': ['dqs_c', 'Forward'],
+        }
+        for prefix in prefixes:
+            for key in connection_matrix_db:
+                sig_eg = prefix+key
+                sig_in = prefix+connection_matrix_db[key][0]
+                # Get attr in egress
+                atr_eg = getattr(self.pdi, sig_eg)
+                # Get attr in ingress
+                atr_in = getattr(pads_ddr5, sig_in)
+                # Determine correct direction
+                direction = connection_matrix_db[key][1]
+                if direction == 'Forward':
+                    print('Connect : ' + sig_in + ' to ' + sig_eg)
+                    self.comb += atr_eg.eq(atr_in)
+                    pass
+                elif direction == 'Reverse':
+                    print('Connect : ' + sig_eg + ' to ' + sig_in)
+                    self.comb += atr_in.eq(atr_eg)
+                    pass
+                else:
+                    raise (
+                        'Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01Alert.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Alert.py
@@ -1,0 +1,68 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01Alert(Module):
+    """DDR5 RCD01 Alert
+    TODO Documentation
+    Handle the alert signal
+
+    TODO Add pulse settings and assertion mode supports
+
+    Module
+    ------
+    d - Input : data
+    q - Output: data
+    ------
+    """
+
+    def __init__(self, if_host_err, if_channel_A_err,
+                 if_channel_B_err, if_ctrl_err):
+        # TODO take errors from channel and create a pulse
+        # TODO implement control
+
+        # TODO Implementation forces no error
+        self.comb += if_host_err.err_n.eq(1)
+
+
+class TestBed(Module):
+    def __init__(self):
+
+        self.if_host_err = If_error()
+        self.if_channel_A_err = If_error()
+        self.if_channel_B_err = If_error()
+        self.if_ctrl_err = If_ctrl_err()
+
+        self.submodules.dut = DDR5RCD01Alert(
+            self.if_host_err, self.if_channel_A_err, self.if_channel_B_err, self.if_ctrl_err)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    for i in range(5):
+        yield
+    logging.debug('Yield from write test.')
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01BCOMSimulationPads.py
+++ b/litedram/DDR5RCD01/DDR5RCD01BCOMSimulationPads.py
@@ -1,0 +1,31 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# Litedram
+from litedram.phy.sim_utils import SimPad, SimulationPads
+
+
+class DDR5RCD01BCOMSimulationPads(SimulationPads):
+    """ DDR5 RCD01 Core Ingress SimulationPads
+    """
+
+    def layout(self, is_dual_channel=True):
+        # BCOM is only used by LRDIMM
+        bcom = [
+            ('bcs_n', 1, False),
+            ('bcom', 3, False),
+            ('brst_n', 1, False),
+            ('bck_t', 1, False),
+            ('bck_c', 1, False),
+        ]
+        channels_prefix = [""] if not is_dual_channel else ["A_", "B_"]
+        return [SimPad(prefix+name, size, io) for prefix in channels_prefix for name, size, io in bcom]
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01Channel.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Channel.py
@@ -1,0 +1,146 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+# Submodules
+from litedram.DDR5RCD01.DDR5RCD01InputBuffer import DDR5RCD01InputBuffer
+from litedram.DDR5RCD01.DDR5RCD01LineBuffer import DDR5RCD01LineBuffer
+from litedram.DDR5RCD01.DDR5RCD01OutputBuffer import DDR5RCD01OutputBuffer
+from litedram.DDR5RCD01.DDR5RCD01ControlCenter import DDR5RCD01ControlCenter
+from litedram.DDR5RCD01.DDR5RCD01Error import DDR5RCD01Error
+
+
+class DDR5RCD01Channel(Module):
+    """DDR5 RCD01 Channel
+    TODO
+    The channel:
+      - Input Buffer
+      - Line Buffer
+      - Output Buffer 
+      - Control Center
+
+    Module
+    ------
+    <interface> : CS,CA,etc.
+    dck, dck_pll 
+    """
+
+    def __init__(self, if_channel_ck, if_channel_rst_n,
+                 if_ibuf, if_obuf_csca, if_obuf_clks,
+                 if_sdram,
+                 if_err, if_lb,
+                 if_ctrl_global,
+                 channel_A,
+                 *args
+                 ):
+
+        # Control interfaces
+        if_ctrl_ibuf = If_ctrl_ibuf()
+        if_ctrl_lbuf = If_ctrl_lbuf()
+        if_ctrl_obuf = If_ctrl_obuf()
+
+        # Input Buffer
+        if_ibuf_2_lbuf = If_channel_ibuf()
+        xibuf = DDR5RCD01InputBuffer(if_ibuf, if_ibuf_2_lbuf, if_ctrl_ibuf)
+        self.submodules += xibuf
+
+        # Line Buffer
+        if_lbuf_2_obuf = If_channel_obuf_csca()
+        xlbuf = DDR5RCD01LineBuffer(
+            if_ibuf_2_lbuf, if_lbuf_2_obuf, if_ctrl_lbuf)
+        self.submodules += xlbuf
+
+        if_clks_2_obuf = If_channel_obuf_clks()
+        # Attach Clock outputs
+        self.comb += if_clks_2_obuf.qack_t.eq(if_channel_ck.ck_t)
+        self.comb += if_clks_2_obuf.qack_c.eq(if_channel_ck.ck_c)
+
+        self.comb += if_clks_2_obuf.qbck_t.eq(if_channel_ck.ck_t)
+        self.comb += if_clks_2_obuf.qbck_c.eq(if_channel_ck.ck_c)
+
+        self.comb += if_clks_2_obuf.qcck_t.eq(if_channel_ck.ck_t)
+        self.comb += if_clks_2_obuf.qcck_c.eq(if_channel_ck.ck_c)
+
+        self.comb += if_clks_2_obuf.qdck_t.eq(if_channel_ck.ck_t)
+        self.comb += if_clks_2_obuf.qdck_c.eq(if_channel_ck.ck_c)
+
+        # Output Buffer
+        xobuf = DDR5RCD01OutputBuffer(
+            if_lbuf_2_obuf, if_clks_2_obuf, if_obuf_csca, if_obuf_clks, if_ctrl_obuf)
+        self.submodules += xobuf
+
+        # Hook inputs
+        if channel_A:
+            logging.debug('I am channel A')
+            # Set direction of glob_settings
+            # Drive the registers
+            if not args:
+                logging.error(
+                    'The global config was not passed to the channel A')
+            # TODO test if kwargs are of these types:
+            if_config_pll = args[0]
+            if_config_lb = args[1]
+            if_config_err = args[2]
+
+            xcontrol_center = DDR5RCD01ControlCenter(if_ibuf_2_lbuf,  # Fetch opcodes from here
+                                                     if_ctrl_ibuf, if_ctrl_lbuf, if_ctrl_obuf,  # Control buffers
+                                                     if_ctrl_global,  # Send settings to channel B
+                                                     channel_A,
+                                                     if_config_pll, if_config_lb, if_config_err  # Send settings to common
+                                                     )
+        else:
+            logging.debug('I am channel B')
+            # Set direction of glob_settings
+            # Driven from the registers
+            xcontrol_center = DDR5RCD01ControlCenter(if_ibuf_2_lbuf,  # Fetch opcodes from here
+                                                     if_ctrl_ibuf, if_ctrl_lbuf, if_ctrl_obuf,  # Control buffers
+                                                     if_ctrl_global,  # Send settings to channel B
+                                                     channel_A
+                                                     )
+
+        self.submodules += xcontrol_center
+
+        # TODO implement error handler
+        xerror = DDR5RCD01Error(iif_err=if_sdram, oif_err=if_err)
+        self.submodules += xerror
+
+
+class TestBed(Module):
+    def __init__(self):
+        #
+        # self.d = Signal()
+        #
+        self.submodules.dut = DDR5RCD01Channel()
+
+
+def run_test(dut):
+    logging.debug('Write test')
+    # yield from dut.regfile.pretty_print_regs()
+    # yield from behav_write_word(0x0,0x0,0x0)
+
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(data):
+    # yield dut.frac_p.eq(data)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    raise NotImplementedError("Test of this block is to be done.")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")

--- a/litedram/DDR5RCD01/DDR5RCD01Chip.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Chip.py
@@ -1,0 +1,61 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.DDR5RCD01BCOMSimulationPads import DDR5RCD01BCOMSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01CoreEgressSimulationPads import DDR5RCD01CoreEgressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01Core import DDR5RCD01Core
+from litedram.DDR5RCD01.I2CSlave import I2CSlave
+from litedram.DDR5RCD01.I3CSlave import I3CSlave
+
+
+class DDR5RCD01Chip(Module):
+    """DDR5 RCD01 Chip
+    TODO clean up imports
+    TODO clean up parameters
+    """
+
+    def __init__(self, pads_ingress, pads_sideband, aligned_reset_zero=False, dq_dqs_ratio=8,
+                 nranks=1, with_sub_channels=False, dimm_type='RDIMM', sideband_type='i2c', **kwargs):
+
+        self.submodules.pads_ingress = pads_ingress
+        self.submodules.pads_sideband = pads_sideband
+
+        pads_egress = DDR5RCD01CoreEgressSimulationPads(databits=4,
+                                                        nranks=nranks,
+                                                        dq_dqs_ratio=4,
+                                                        with_sub_channels=with_sub_channels)
+        self.submodules.pads_egress = pads_egress
+
+        # Sideband traffic handler
+        if sideband_type == 'i2c':
+            iXC_slave = I2CSlave(pads_sideband)
+        elif sideband_type == 'i3c':
+            iXC_slave = I3CSlave(pads_sideband)
+        else:
+            raise (NotImplemented, 'Only i2c and i3c are supported options.')
+        sideband_2_core = iXC_slave.sideband_2_core
+
+        core = DDR5RCD01Core(pads_ingress, sideband_2_core)
+        if dimm_type == 'RDIMM':
+            # TODO potentially remove this if
+            pass
+        if dimm_type == 'LRDIMM':
+            # TODO Implement BCOM traffic handler
+            pads_bcom = DDR5RCD01BCOMSimulationPads(databits=4,
+                                                    nranks=nranks,
+                                                    dq_dqs_ratio=4,
+                                                    with_sub_channels=with_sub_channels)
+
+            pads_bcom = core.pads_bcom
+            # TODO replace print with preffered style of logging
+            print('Warning : LRDIMM is not supported')
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is to be done.")

--- a/litedram/DDR5RCD01/DDR5RCD01Common.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Common.py
@@ -1,0 +1,150 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+# Submodules
+from litedram.DDR5RCD01.DDR5RCD01Loopback import DDR5RCD01Loopback
+from litedram.DDR5RCD01.DDR5RCD01Alert import DDR5RCD01Alert
+from litedram.DDR5RCD01.DDR5RCD01PLL import DDR5RCD01PLL
+
+
+class DDR5RCD01Common(Module):
+    """DDR5 RCD01 Common
+    TODO
+    The common:
+        - PLL
+        - Loopback
+        - Error/alert
+        - QRST
+
+    Module
+    ------
+    <interface> : CS,CA,etc.
+    dck, dck_pll 
+    """
+
+    def __init__(self,
+                 # Distribute clock and reset
+                 if_host_ck, if_host_rst_n,
+                 if_channel_A_ck, if_channel_A_rst_n,
+                 if_channel_B_ck, if_channel_B_rst_n,
+                 if_sdram_A_rst_n, if_sdram_B_rst_n,
+                 # Error
+                 if_host_err,
+                 if_channel_A_err,
+                 if_channel_B_err,
+                 # Loopback
+                 if_host_lb,
+                 if_rcd_lb,
+                 if_sdram_A_lb,
+                 if_sdram_B_lb,
+                 if_channel_A_lb,
+                 if_channel_B_lb,
+                 # Control interfaces
+                 if_ctrl_pll, if_ctrl_lb, if_ctrl_err,
+                 ):
+
+        # TODO Split the channel config
+
+        xlb = DDR5RCD01Loopback(if_host_ck,
+                                if_host_lb,
+                                if_rcd_lb,
+                                if_sdram_A_lb,
+                                if_sdram_B_lb,
+                                if_channel_A_lb,
+                                if_channel_B_lb,
+                                if_ctrl_lb)
+        self.submodules += xlb
+
+        xalert = DDR5RCD01Alert(if_host_err, if_channel_A_err,
+                                if_channel_B_err, if_ctrl_err)
+        self.submodules += xalert
+
+        xpll = DDR5RCD01PLL(if_host_ck, if_channel_A_ck,
+                            if_channel_B_ck, if_ctrl_pll)
+        self.submodules += xpll
+
+        # Reset distribution
+        self.comb += if_channel_A_rst_n.rst_n.eq(if_host_rst_n.rst_n)
+        self.comb += if_channel_B_rst_n.rst_n.eq(if_host_rst_n.rst_n)
+        self.comb += if_sdram_A_rst_n.rst_n.eq(if_host_rst_n.rst_n)
+        self.comb += if_sdram_B_rst_n.rst_n.eq(if_host_rst_n.rst_n)
+
+
+class TestBed(Module):
+    def __init__(self):
+        if_host_ck = If_ck()
+        if_host_rst_n = If_rst_n()
+
+        if_channel_A_ck = If_ck()
+        if_channel_A_rst_n = If_rst_n()
+        if_channel_B_ck = If_ck()
+        if_channel_B_rst_n = If_rst_n()
+        if_sdram_A_rst_n = If_rst_n()
+        if_sdram_B_rst_n = If_rst_n()
+        # Error
+        if_host_err = If_error()
+        if_channel_A_err = If_error()
+        if_channel_B_err = If_error()
+        # Loopback
+        if_host_lb = If_lb()
+        if_rcd_lb = If_lb()
+        if_sdram_A_lb = If_lb()
+        if_sdram_B_lb = If_lb()
+        if_channel_A_lb = If_int_lb()
+        if_channel_B_lb = If_int_lb()
+        # Control interfaces
+        if_ctrl_pll = If_ctrl_pll()
+        if_ctrl_lb = If_ctrl_lb()
+        if_ctrl_err = If_ctrl_err()
+        
+        self.clock_domains.dck_t = ClockDomain(name="dck_t")
+        self.clock_domains.dck_c = ClockDomain(name="dck_c")
+
+        self.sync += self.dck_t.clk.eq(~self.dck_t.clk)
+        self.comb += self.dck_c.clk.eq(~self.dck_t.clk)
+
+        self.comb += if_host_ck.ck_t.eq(self.dck_t.clk)
+        self.comb += if_host_ck.ck_c.eq(self.dck_c.clk)
+
+        self.submodules.dut = DDR5RCD01Common(if_host_ck, if_host_rst_n,
+                                              if_channel_A_ck, if_channel_A_rst_n,
+                                              if_channel_B_ck, if_channel_B_rst_n,
+                                              if_sdram_A_rst_n, if_sdram_B_rst_n,
+                                              if_host_err,
+                                              if_channel_A_err,
+                                              if_channel_B_err,
+                                              if_host_lb,
+                                              if_rcd_lb,
+                                              if_sdram_A_lb,
+                                              if_sdram_B_lb,
+                                              if_channel_A_lb,
+                                              if_channel_B_lb,
+                                              if_ctrl_pll, if_ctrl_lb, if_ctrl_err)
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    for i in range(5):
+        yield
+    logging.debug('Yield from write test.')
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01ControlCenter.py
+++ b/litedram/DDR5RCD01/DDR5RCD01ControlCenter.py
@@ -1,0 +1,520 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# RCD
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+# Submodules
+from litedram.DDR5RCD01.DDR5RCD01RegFile import DDR5RCD01RegFile
+from litedram.DDR5RCD01.DDR5RCD01Pages import DDR5RCD01Pages
+
+
+class DDR5RCD01ControlCenter(Module):
+    """DDR5 RCD01 Control Center
+    TODO Documentation
+
+    -- 3.8 on hard reset
+    POWERDOWN - meaning no power supplied, note, this is ambiguous*
+    Device should start in the RESET state. DRST_n shall be asserted.
+    Effects:
+      - floating input receivers
+      - non-sticky registers are restored to default (preferred 0)
+      - QRST_n is asserted
+      - other outputs are to flow, except QCS[x]_n which should be asserted
+    This state is also called the low-power state.  
+
+    *Powerdown is widely used to describe a power-state, in which
+    the bias circuitry is disabled, however, there is a stable power supply
+    on the vdd pin.
+
+    Next:
+      - DRST_n is deasserted
+      - DCS_n are deasserted
+      - Host starts the dck clock
+      - host writes to coarse and fine grain frequency registers 
+      - host writes to DCA input mode (DDR, SDR)
+      - wait for PLL to re-lock
+    Next, training:
+      - DCS and DCA training
+      - BCS and BCOM training (if applicable)
+
+    Note, qrst_n remains asserted until a proper command register write.
+
+    After initilization, a proper write sequence should occur to configure the application.
+    -- 3.9 on soft reset (vdd remains on)
+    TODO analyze
+
+    TODO List of states:
+    HARD_RESET
+    SOFT_RESET
+    INITILIZATION
+    NORMAL
+    TRAINING (4 modes)
+    POWER_SAVINGS (4 modes)
+
+    Module
+    ------
+    d - Input : data
+    q - Output: data
+    ------
+    """
+
+    def __init__(self,
+                 if_ibuf_2_lbuf,  # Fetch opcodes from here
+                 if_ctrl_ibuf, if_ctrl_lbuf, if_ctrl_obuf,  # Control buffers
+                 if_ctrl_global,  # Send settings to channel B
+                 is_channel_A,
+                 *args):
+
+        bank_d = Signal(8)
+        bank_page_pointer = Signal(8)
+        bank_we = Signal()
+        page_addr = Signal(8)
+        page_copy = Array(Signal(CW_REG_BIT_SIZE)
+                          for y in range(CW_PAGE_PTRS_NUM))
+
+        # TODO Pages are currently unused, so their number is reduced to speed-up the simulation
+        xbank_file = DDR5RCD01Pages(
+            bank_d, bank_we, bank_page_pointer, page_copy, page_addr, cw_page_num=6)
+        self.submodules += xbank_file
+        banks = xbank_file.pages
+
+        reg_d = Signal(8)
+        reg_addr = Signal(8)
+        reg_we = Signal()
+        reg_q = Signal(CW_REG_BIT_SIZE)
+
+        xreg_file = DDR5RCD01RegFile(reg_d, reg_addr, reg_we, reg_q, page_copy)
+        self.submodules += xreg_file
+
+        regs = xreg_file.registers
+        page_addr = regs[ADDR_CW_PAGE]
+        page_copy = banks[bank_page_pointer]
+        bank_page_pointer = regs[ADDR_CW_PAGE]
+
+        if is_channel_A:
+            logging.debug('I am channel A')
+            # Set direction of glob_settings
+            # Drive the registers
+            if not args:
+                logging.error(
+                    'The global config was not passed to the channel A')
+            if_config_pll = args[0]
+            if_config_lb = args[1]
+            if_config_err = args[2]
+
+        """
+        CSR, RW, PAGE
+        This section described the CSR of the device. Connects physical functions
+        to its control words in Control Registers. 
+
+        """
+        # Boot Image
+        boot_image_rw00_rw5f = Array(Signal(CW_REG_BIT_SIZE)
+                                     for y in range(CW_DA_REGS_NUM))
+        DEBUG_NUMBER = 0x39
+        boot_image_rw00_rw5f = [DEBUG_NUMBER]*CW_DA_REGS_NUM
+
+        """ Custom Internal CSR
+          Implementation dependent, not constrained by the JEDEC spec.
+
+        """
+        rw_custom_csr = Signal(8)  # Expand width as needed
+        RW_CUSTOM_INBUF_EN = rw_custom_csr[0]
+        # ------------------------0b76543210
+        rw_custom_csr_boot_word = 0b00000001
+
+        self.comb += if_ctrl_ibuf.en.eq(RW_CUSTOM_INBUF_EN)
+
+        """ Table 98
+            RW00
+            Global Features Control Word
+        """
+        RW_GLOBAL_FEATURES = 0x00
+        COMMAND_ADDRESS_RATE = regs[RW_GLOBAL_FEATURES][0]
+        SDR_MODES = regs[RW_GLOBAL_FEATURES][1]
+        CA_PASS_THROUGH_MODE_ENABLE = regs[RW_GLOBAL_FEATURES][2]
+        CA_PASS_THROUGH_MODE_RANK_SELECTION = regs[RW_GLOBAL_FEATURES][3]
+        BCOM_PASS_THROUGH_MODE_ENABLE = regs[RW_GLOBAL_FEATURES][4]
+        OUTPUT_INVERSION_ENABLE = regs[RW_GLOBAL_FEATURES][5]
+        POWER_DOWN_MODE_ENABLE = regs[RW_GLOBAL_FEATURES][6]
+        TRANSPARENT_MODE_ENABLE = regs[RW_GLOBAL_FEATURES][7]
+        # -----------------------------------------0b76543210
+        boot_image_rw00_rw5f[RW_GLOBAL_FEATURES] = 0b00100011
+
+        """ Table 99
+            RW01
+            Parity, CMD Blocking and Alert Global Control Word
+            Note, for block_n signals the '0' means block
+        """
+        RW_SECONDARY_FEATURES = 0x01
+        PARITY_CHECKING_ENABLE = regs[RW_SECONDARY_FEATURES][0]
+        DRAM_FORWARD_CMDS_BLOCK_N = regs[RW_SECONDARY_FEATURES][1]
+        # RESERVED = regs[RW_SECONDARY_FEATURES][2]
+        DB_FORWARD_CMDS_BLOCK_N = regs[RW_SECONDARY_FEATURES][3]
+        # RESERVED = regs[RW_SECONDARY_FEATURES][4]
+        HOST_IF_TRAINING_FEEDBACK = regs[RW_SECONDARY_FEATURES][5]
+        ALERT_ASSERTION_MODE = regs[RW_SECONDARY_FEATURES][6]
+        ALERT_REENABLE = regs[RW_SECONDARY_FEATURES][7]
+        # --------------------------------------------0b76543210
+        boot_image_rw00_rw5f[RW_SECONDARY_FEATURES] = 0b10000010
+
+        """ Table 107
+            RW08
+            Clock driver enable control word
+            regs[0x08]
+            """
+        RW_CLOCK_OUTPUT_CONTROL = 0x08
+        QACK_CLK_ENABLE = regs[RW_CLOCK_OUTPUT_CONTROL][0]
+        QBCK_CLK_ENABLE = regs[RW_CLOCK_OUTPUT_CONTROL][1]
+        QCCK_CLK_ENABLE = regs[RW_CLOCK_OUTPUT_CONTROL][2]
+        QDCK_CLK_ENABLE = regs[RW_CLOCK_OUTPUT_CONTROL][3]
+        # RESERVED = regs[RW_CLOCK_OUTPUT_CONTROL][4]
+        BCK_CLK_ENABLE = regs[RW_CLOCK_OUTPUT_CONTROL][5]
+        # RESERVED = regs[RW_CLOCK_OUTPUT_CONTROL][6]
+        # RESERVED = regs[RW_CLOCK_OUTPUT_CONTROL][7]
+        # ----------------------------------------------0b76543210
+        boot_image_rw00_rw5f[RW_CLOCK_OUTPUT_CONTROL] = 0b11000101
+
+        self.comb += if_ctrl_obuf.oe_qack_t.eq(QACK_CLK_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qack_c.eq(QACK_CLK_ENABLE)
+
+        self.comb += if_ctrl_obuf.oe_qbck_t.eq(QBCK_CLK_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qbck_c.eq(QBCK_CLK_ENABLE)
+
+        self.comb += if_ctrl_obuf.oe_qcck_t.eq(QCCK_CLK_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qcck_c.eq(QCCK_CLK_ENABLE)
+
+        self.comb += if_ctrl_obuf.oe_qdck_t.eq(QDCK_CLK_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qdck_c.eq(QDCK_CLK_ENABLE)
+
+        """ Table 108 
+            RW09
+            Output address and Control Enable Control Word
+            regs[0x09]
+            """
+        RW_OUTPUT_CONTROL = 0x09
+        QACA_OUTPUT_ENABLE = regs[RW_OUTPUT_CONTROL][0]
+        QBCA_OUTPUT_ENABLE = regs[RW_OUTPUT_CONTROL][1]
+        DCS_N_AND_QCS_N_ENABLE = regs[RW_OUTPUT_CONTROL][2]
+        BCS_BCOM_BRST_ENABLE = regs[RW_OUTPUT_CONTROL][3]
+        QBACA13_OUTPUT_ENABLE = regs[RW_OUTPUT_CONTROL][4]
+        QACS_N_ENABLE = regs[RW_OUTPUT_CONTROL][5]
+        QBCS_N_ENABLE = regs[RW_OUTPUT_CONTROL][6]
+        # RESERVED = regs[RW_OUTPUT_CONTROL][7]
+        # ----------------------------------------0b76543210
+        boot_image_rw00_rw5f[RW_OUTPUT_CONTROL] = 0b01100111
+
+        # Output enable
+        self.comb += if_ctrl_obuf.oe_qaca_a.eq(QACA_OUTPUT_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qaca_b.eq(QBCA_OUTPUT_ENABLE)
+
+        self.comb += if_ctrl_obuf.oe_qacs_a_n.eq(QACS_N_ENABLE)
+        self.comb += if_ctrl_obuf.oe_qacs_b_n.eq(QBCS_N_ENABLE)
+
+        # DCS, DCA Output inversion
+        self.comb += if_ctrl_obuf.o_inv_en_qacs_a_n.eq(0)
+        self.comb += if_ctrl_obuf.o_inv_en_qacs_b_n.eq(0)
+
+        self.comb += if_ctrl_obuf.o_inv_en_qaca_a.eq(0)
+        self.comb += if_ctrl_obuf.o_inv_en_qaca_b.eq(OUTPUT_INVERSION_ENABLE)
+
+        # Clock output inversion
+        self.comb += if_ctrl_obuf.o_inv_en_qack_t.eq(OUTPUT_INVERSION_ENABLE)
+        self.comb += if_ctrl_obuf.o_inv_en_qack_c.eq(OUTPUT_INVERSION_ENABLE)
+
+        self.comb += if_ctrl_obuf.o_inv_en_qbck_t.eq(OUTPUT_INVERSION_ENABLE)
+        self.comb += if_ctrl_obuf.o_inv_en_qbck_c.eq(OUTPUT_INVERSION_ENABLE)
+
+        self.comb += if_ctrl_obuf.o_inv_en_qcck_t.eq(OUTPUT_INVERSION_ENABLE)
+        self.comb += if_ctrl_obuf.o_inv_en_qcck_c.eq(OUTPUT_INVERSION_ENABLE)
+
+        self.comb += if_ctrl_obuf.o_inv_en_qdck_t.eq(OUTPUT_INVERSION_ENABLE)
+        self.comb += if_ctrl_obuf.o_inv_en_qdck_c.eq(OUTPUT_INVERSION_ENABLE)
+
+        """ Table 115 
+            RW11
+            Command Latency Adder Configuration Control Word
+            regs[0x11]
+        """
+        RW_LATENCY_ADDER = 0x11
+        LATENCY_ADDER_OP_0 = regs[RW_LATENCY_ADDER][0]
+        LATENCY_ADDER_OP_1 = regs[RW_LATENCY_ADDER][1]
+        LATENCY_ADDER_OP_2 = regs[RW_LATENCY_ADDER][2]
+        # RESERVED = regs[RW_LATENCY_ADDER][3]
+        # RESERVED = regs[RW_LATENCY_ADDER][4]
+        # RESERVED = regs[RW_LATENCY_ADDER][5]
+        # RESERVED = regs[RW_LATENCY_ADDER][6]
+        # RESERVED = regs[RW_LATENCY_ADDER][7]
+        latency_cat = Cat(LATENCY_ADDER_OP_0,
+                          LATENCY_ADDER_OP_1,
+                          LATENCY_ADDER_OP_2)
+        # ----------------------------------------0b76543210
+        boot_image_rw00_rw5f[RW_LATENCY_ADDER] = 0b000000001
+
+        self.comb += if_ctrl_lbuf.sel_latency_add.eq(latency_cat)
+
+        """
+          Parity checker
+        """
+        # self.comb += parity_error.eq(0)
+
+        """
+          CS Logic
+          The control center forwards the cmd to the deserializer by the 
+          If_ctrl_lbuf interface. The deserializer is placed inside of the lbuf.
+          (Not optimal for synthesis).
+
+          Commands (CA and CS_n) are forwarded in normal mode:
+          1. Detect active CS_n
+          2. Send the command to the DRAM interface
+          Use Cases: 
+          
+          1 UI command:
+            - CS is low
+            - CA on this edge and next is captured (c.f. RCD model clocking)
+          
+          2 UI commands: 
+            - CS is low only during 1st UI. Can be low if the non-target termination
+            is being signalled. c.f. Table 4
+            - CA must be captured on 2 more edges
+
+          Parity error detected during a 1 UI command
+
+          Parity error detected during a 2 UI command
+
+          DRAM Interface Blocking Mode is enabled
+
+          CA Pass-through Mode is enabled
+
+          The decode portion should always listen
+        """
+
+        debug_parity_error_occured = Signal()
+        self.comb += debug_parity_error_occured.eq(0)
+
+        debug_non_target_termination_signalled = Signal()
+        self.comb += debug_non_target_termination_signalled.eq(0)
+
+        """
+          Drive deser if a command is sent
+        """
+        # Normal forward
+        xfsm_cslogic = FSM(reset_state="RESET")
+        self.submodules += xfsm_cslogic
+
+        fetch_decode_en = Signal()
+        self.comb += fetch_decode_en.eq(1)
+
+        xfsm_cslogic.act(
+            "RESET",
+            If(
+                fetch_decode_en,
+                NextState("IDLE")
+            )
+        )
+        xfsm_cslogic.act(
+            "IDLE",
+            If(
+                if_ibuf_2_lbuf.dcs_n == 0x00,
+                if_ctrl_lbuf.deser_sel_lower_upper.eq(0),
+                if_ctrl_lbuf.deser_ca_d_en.eq(1),
+                if_ctrl_lbuf.deser_ca_q_en.eq(0),
+                if_ctrl_lbuf.deser_cs_n_d_en.eq(1),
+                if_ctrl_lbuf.deser_cs_n_q_en.eq(0),
+                NextState("S_0a")
+            ).Else(
+                if_ctrl_lbuf.deser_sel_lower_upper.eq(0),
+                if_ctrl_lbuf.deser_ca_d_en.eq(0),
+                if_ctrl_lbuf.deser_ca_q_en.eq(0),
+                if_ctrl_lbuf.deser_cs_n_d_en.eq(0),
+                if_ctrl_lbuf.deser_cs_n_q_en.eq(0),
+            )
+        )
+        xfsm_cslogic.act(
+            "S_0a",
+            if_ctrl_lbuf.deser_sel_lower_upper.eq(1),
+            if_ctrl_lbuf.deser_ca_d_en.eq(1),
+            if_ctrl_lbuf.deser_ca_q_en.eq(0),
+            if_ctrl_lbuf.deser_cs_n_d_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_q_en.eq(0),
+            NextState("S_0b")
+        )
+        xfsm_cslogic.act(
+            "S_0b",
+            if_ctrl_lbuf.deser_sel_lower_upper.eq(0),
+            if_ctrl_lbuf.deser_ca_d_en.eq(1),
+            if_ctrl_lbuf.deser_ca_q_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_d_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_q_en.eq(1),
+            NextState("S_1a")
+        )
+        xfsm_cslogic.act(
+            "S_1a",
+            if_ctrl_lbuf.deser_sel_lower_upper.eq(1),
+            if_ctrl_lbuf.deser_ca_d_en.eq(1),
+            if_ctrl_lbuf.deser_ca_q_en.eq(0),
+            if_ctrl_lbuf.deser_cs_n_d_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_q_en.eq(0),
+            NextState("S_1b")
+        )
+        xfsm_cslogic.act(
+            "S_1b",
+            if_ctrl_lbuf.deser_sel_lower_upper.eq(0),
+            if_ctrl_lbuf.deser_ca_d_en.eq(0),
+            if_ctrl_lbuf.deser_ca_q_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_d_en.eq(0),
+            if_ctrl_lbuf.deser_cs_n_q_en.eq(1),
+            NextState("POST")
+        )
+        xfsm_cslogic.act(
+            "POST",
+            if_ctrl_lbuf.deser_sel_lower_upper.eq(0),
+            if_ctrl_lbuf.deser_ca_d_en.eq(0),
+            if_ctrl_lbuf.deser_ca_q_en.eq(1),
+            if_ctrl_lbuf.deser_cs_n_d_en.eq(0),
+            if_ctrl_lbuf.deser_cs_n_q_en.eq(1),
+            NextState("IDLE")
+        )
+
+        # TODO expand features of the main FSM here
+        """ Modal FSM
+        RESET_HARD - reset after power-up
+
+        RESET_SOFT - reset after drst_n assertion
+        
+        INIT_HARD  - initialize after RESET_HARD
+        In the init state a boot image is loaded into the CSRs. It is done
+        via a sequence of writes to the Register Files. The init state
+        should then last approximately (number of directly addressed
+        registers =96 ) cycles. After this initial configuration the RCD model
+        should go into normal operation and be ready to receive commands 
+        from the host device.
+
+        INIT_SOFT  - initialize after RESET_SOF
+        
+        NORMAL     - normal for RCD means listening for commands
+        
+        possible other states
+        PRE_TRAINING, TRAINING, POST_TRAINING (?)
+        """
+        xfsm = FSM(reset_state="RESET_HARD")
+        self.submodules += xfsm
+
+        xfsm.act(
+            "RESET_HARD",
+            NextState("INIT_HARD")
+        )
+
+        rw_boot_image_reader_start = Signal()
+        rw_boot_image_reader_finish = Signal()
+
+        xfsm.act(
+            "INIT_HARD",
+            NextValue(rw_custom_csr, rw_custom_csr_boot_word),
+            rw_boot_image_reader_start.eq(1),
+
+            If(
+                rw_boot_image_reader_finish,
+                NextState("NORMAL")
+            )
+        )
+        xfsm.act(
+            "NORMAL",
+            If(
+                CA_PASS_THROUGH_MODE_ENABLE,
+                NextState("CA_PASS_THROUGH_MODE")
+            ).Else(
+                NextState("NORMAL"),
+            )
+        )
+        xfsm.act(
+            "CA_PASS_THROUGH_MODE",
+            If(
+                ~CA_PASS_THROUGH_MODE_ENABLE,
+                NextState("NORMAL")
+            )
+        )
+
+        # Debug information
+        xfsm_debug_state = Signal(8)
+        self.comb += If(xfsm.ongoing("RESET_HARD"), xfsm_debug_state.eq(0))
+        self.comb += If(xfsm.ongoing("INIT_HARD"), xfsm_debug_state.eq(1))
+        self.comb += If(xfsm.ongoing("NORMAL"), xfsm_debug_state.eq(2))
+        self.comb += If(xfsm.ongoing("CA_PASS_THROUGH_MODE"),
+                        xfsm_debug_state.eq(3))
+
+        # Boot image reader
+        rw_counter = Signal(int(CW_DA_REGS_NUM).bit_length())
+        boot_word = Signal(int(CW_DA_REGS_NUM).bit_length())
+
+        for i in range(CW_DA_REGS_NUM):
+            self.comb += If(
+                rw_counter == i,
+                boot_word.eq(boot_image_rw00_rw5f[i])
+            )
+
+        self.sync += If(
+            rw_counter == CW_DA_REGS_NUM,
+            rw_counter.eq(rw_counter),
+            rw_boot_image_reader_finish.eq(1)
+        ).Else(
+            If(
+                rw_boot_image_reader_start,
+                rw_counter.eq(rw_counter+1)
+            )
+        )
+
+        self.comb += If(rw_boot_image_reader_start &
+                        (rw_counter < CW_DA_REGS_NUM) &
+                        (~rw_boot_image_reader_finish),
+                        reg_we.eq(1),
+                        reg_d.eq(boot_word),
+                        reg_addr.eq(rw_counter),
+                        )
+
+
+class TestBed(Module):
+    def __init__(self):
+
+        self.d = Signal()
+
+        self.submodules.regfile = DDR5RCD01ControlCenter(d=self.d)
+        # print(verilog.convert(self.regfile))
+
+
+def run_test(dut):
+    logging.debug('Write test')
+    yield from behav_write_word(0x0)
+    yield from behav_write_word(0x1)
+    yield from behav_write_word(0x0)
+    yield from behav_write_word(0x1)
+    yield from behav_write_word(0x0)
+
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(tb):
+    #
+    yield tb.d.eq(1)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    raise NotImplementedError("Test of this block is to be done.")
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01Core.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Core.py
@@ -1,0 +1,272 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from operator import xor
+from migen import *
+from migen.fhdl import verilog
+# RCD
+from litedram.DDR5RCD01.RCD_utils import *
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+# Simulation Pads
+from litedram.DDR5RCD01.DDR5RCD01CoreEgressSimulationPads import DDR5RCD01CoreEgressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01CoreIngressSimulationPads import DDR5RCD01CoreIngressSimulationPads
+# Submodules
+from litedram.DDR5RCD01.DDR5RCD01Channel import DDR5RCD01Channel
+from litedram.DDR5RCD01.DDR5RCD01Common import DDR5RCD01Common
+
+
+class DDR5RCD01Core(Module):
+    """DDR5 RCD01 Core
+    TODO Documentation
+    Primary function of the Core is to buffer the Command/Address (CA) bus, chip selects and clock
+    between the host controller and the DRAMs
+    In the LRDIMM use case, a BCOM bus is created to communicate with the data buffers.
+
+    The Core consists of 2 independent channels and some common logic, e.g.: clocking.
+
+    The term "Definintion X.Y.Z" refers to the X.Y.Z section of the JEDEC Standard DDR5 Registering
+    Clock Driver Definition (DDR5RCD01).
+
+    """
+
+    def __init__(self, pads_ingress, pads_sideband, aligned_reset_zero=False, dq_dqs_ratio=8,
+                 nranks=1, is_dual_channel=False, **kwargs):
+        self.submodules.pads_ingress = pads_ingress
+        self.submodules.pads_sideband = pads_sideband
+
+        pads_egress = DDR5RCD01CoreEgressSimulationPads(
+            is_dual_channel=is_dual_channel)
+
+        self.submodules.pads_egress = pads_egress
+        # Internal implementation
+        # TODO Integrate simulation pads and interfaces
+        if_sdram_A_rst_n = If_rst_n()
+        self.comb += if_sdram_A_rst_n.rst_n.eq(self.pads_egress.A_qrst_n)
+
+        # Host <-> common
+        if_host_ck = If_ck()
+        self.comb += if_host_ck.ck_t.eq(self.pads_ingress.dck_t)
+        self.comb += if_host_ck.ck_c.eq(self.pads_ingress.dck_c)
+        if_host_rst_n = If_rst_n()
+        self.comb += if_host_rst_n.rst_n.eq(self.pads_ingress.drst_n)
+        if_host_err = If_error()
+        self.comb += if_host_err.err_n.eq(self.pads_ingress.alert_n)
+        if_host_lb = If_lb()
+        self.comb += if_host_lb.lbd.eq(self.pads_ingress.qlbd)
+        self.comb += if_host_lb.lbs.eq(self.pads_ingress.qlbd)
+        # Host <-> channel A
+        if_ibuf_A = If_channel_ibuf()
+        self.comb += if_ibuf_A.dca.eq(self.pads_ingress.A_dca)
+        self.comb += if_ibuf_A.dcs_n.eq(self.pads_ingress.A_dcs_n)
+        self.comb += if_ibuf_A.dpar.eq(self.pads_ingress.A_dpar)
+        # Channel A <-> SDRAM
+        if_obuf_csca_A = If_channel_obuf_csca()
+        self.comb += if_obuf_csca_A.qacs_a_n.eq(self.pads_egress.A_qacs_a_n)
+        self.comb += if_obuf_csca_A.qaca_a.eq(self.pads_egress.A_qaca_a)
+        self.comb += if_obuf_csca_A.qacs_b_n.eq(self.pads_egress.A_qacs_b_n)
+        self.comb += if_obuf_csca_A.qaca_b.eq(self.pads_egress.A_qaca_b)
+        if_obuf_clks_A = If_channel_obuf_clks()
+        self.comb += if_obuf_clks_A.qack_t.eq(self.pads_egress.A_qack_t)
+        self.comb += if_obuf_clks_A.qack_c.eq(self.pads_egress.A_qack_c)
+        self.comb += if_obuf_clks_A.qbck_t.eq(self.pads_egress.A_qbck_t)
+        self.comb += if_obuf_clks_A.qbck_c.eq(self.pads_egress.A_qbck_c)
+        self.comb += if_obuf_clks_A.qcck_t.eq(self.pads_egress.A_qcck_t)
+        self.comb += if_obuf_clks_A.qcck_c.eq(self.pads_egress.A_qcck_c)
+        self.comb += if_obuf_clks_A.qdck_t.eq(self.pads_egress.A_qdck_t)
+        self.comb += if_obuf_clks_A.qdck_c.eq(self.pads_egress.A_qdck_c)
+
+        if_sdram_A = If_error()
+        self.comb += if_sdram_A.err_n.eq(self.pads_egress.A_derror_in_n)
+
+        if_sdram_B_rst_n = If_rst_n()
+        self.comb += if_sdram_B_rst_n.rst_n.eq(self.pads_egress.B_qrst_n)
+
+        # Host <-> channel B
+        if_ibuf_B = If_channel_ibuf()
+        # Channel B <-> SDRAM
+        if_obuf_csca_B = If_channel_obuf_csca()
+        if_obuf_clks_B = If_channel_obuf_clks()
+        if_sdram_B = If_error()
+
+        # Channel A
+        if_channel_A_ck = If_ck()
+        if_channel_A_rst_n = If_rst_n()
+        if_channel_A_err = If_error()
+        if_channel_A_lb = If_int_lb()
+
+        # Global config to common
+        if_ctrl_pll = If_ctrl_pll()
+        if_ctrl_err = If_ctrl_err()
+        if_ctrl_lb = If_ctrl_lb()
+
+        # Global config to channel B
+        if_ctrl_global = If_channel_config_global()
+        is_channel_A = True
+        channel_A = DDR5RCD01Channel(
+            if_channel_A_ck, if_channel_A_rst_n,
+            if_ibuf_A,  # Host interfaces
+            if_obuf_csca_A, if_obuf_clks_A, if_sdram_A,  # SDRAM interfaces
+            if_channel_A_err, if_channel_A_lb,  # Common
+            if_ctrl_global,  # A<->B config
+            is_channel_A,
+            if_ctrl_pll, if_ctrl_lb, if_ctrl_err,  # Optional args! Only channel A
+        )
+        self.submodules += channel_A
+
+        # Channel B
+        if_channel_B_ck = If_ck()
+        if_channel_B_rst_n = If_rst_n()
+        if_channel_B_err = If_error()
+        if_channel_B_lb = If_int_lb()
+
+        if is_dual_channel:
+            is_channel_B = not is_channel_A
+            channel_B = DDR5RCD01Channel(if_channel_B_ck, if_channel_B_rst_n,
+                                         if_ibuf_B,  # Host interfaces
+                                         if_obuf_csca_B, if_obuf_clks_B, if_sdram_B,  # SDRAM interfaces
+                                         if_channel_B_err, if_channel_B_lb,  # Common
+                                         if_ctrl_global,  # A<->B config
+                                         is_channel_B,
+                                         )
+            self.submodules += channel_B
+
+        # Common part
+
+        if_sdram_A_lb = If_lb()
+        if_sdram_B_lb = If_lb()
+        if_rcd_lb = If_lb()
+
+        common = DDR5RCD01Common(if_host_ck, if_host_rst_n,  # Distribute clock and reset
+                                 if_channel_A_ck, if_channel_A_rst_n,
+                                 if_channel_B_ck, if_channel_B_rst_n,
+                                 if_sdram_A_rst_n, if_sdram_B_rst_n,
+                                 # Error
+                                 if_host_err,
+                                 if_channel_A_err,
+                                 if_channel_B_err,
+                                 # Loopback
+                                 if_host_lb,
+                                 if_rcd_lb,
+                                 if_sdram_A_lb,
+                                 if_sdram_B_lb,
+                                 if_channel_A_lb,
+                                 if_channel_B_lb,
+                                 # Control interfaces
+                                 if_ctrl_pll, if_ctrl_lb, if_ctrl_err,
+                                 )
+        self.submodules += common
+
+        # TODO feed egress from interfaces
+
+
+class TestBed(Module):
+    def __init__(self):
+        is_dual_channel = True
+        self.pi = DDR5RCD01CoreIngressSimulationPads(
+            is_dual_channel=is_dual_channel)
+        self.po = DDR5RCD01CoreEgressSimulationPads(
+            is_dual_channel=is_dual_channel)
+        self.submodules.dut = DDR5RCD01Core(
+            self.pi, self.po, is_dual_channel=is_dual_channel)
+
+        self.clock_domains.dck_t = ClockDomain(name="dck_t")
+        self.clock_domains.dck_c = ClockDomain(name="dck_c")
+
+        self.sync += self.dck_t.clk.eq(~self.dck_t.clk)
+        self.comb += self.dck_c.clk.eq(~self.dck_t.clk)
+        self.comb += self.pi.dck_t.eq(self.dck_t.clk)
+        self.comb += self.pi.dck_c.eq(self.dck_c.clk)
+        # print(verilog.convert(self.dut))
+
+
+def seq_cmds(tb):
+    # TODO all commands are passed as if they were 2UIs long. To be fixed.
+    # Single UI command
+    yield from n_ui_dram_command(tb, nums=[0x01, 0x02])
+    # 2 UI commands
+    yield from n_ui_dram_command(tb, nums=[0x01, 0x02, 0x03, 0x04])
+    yield from n_ui_dram_command(tb, nums=[0x0A, 0x0B, 0x0C, 0x0D], non_target_termination=True)
+    yield from n_ui_dram_command(tb, nums=[0xDE, 0xAD, 0xBA, 0xBE], non_target_termination=True)
+    yield from n_ui_dram_command(tb, nums=[0xC0, 0xDE, 0xF0, 0x0D])
+
+
+def n_ui_dram_command(tb, nums, non_target_termination=False):
+    """
+    This function drives the interface with as in:
+        "JEDEC 82-511 Figure 7
+        One UI DRAM Command Timing Diagram"
+    
+    Nums can be any length to incroporate two, or more, UI commands
+    
+    The non target termination parameter extends the DCS assertion to the 2nd UI
+    """
+    SEQ_INACTIVE = [~0, 0]
+    yield from drive_init(tb)
+    yield from set_parity(tb)
+
+    sequence = [SEQ_INACTIVE]
+    for id, num in enumerate(nums):
+        if non_target_termination:
+            if id in [0,1,2,3]:
+                sequence.append([0b00, num])
+            else:
+                sequence.append([0b11, num])
+        else:
+            if id in [0, 1]:
+                sequence.append([0b00, num])
+            else:
+                sequence.append([0b11, num])
+
+    sequence.append(SEQ_INACTIVE)
+
+    for seq_cs, seq_ca in sequence:
+        logging.debug(str(seq_cs) + " " + str(seq_ca))
+        yield from drive_cs_ca(seq_cs, seq_ca)
+    for i in range(3):
+        yield
+
+
+def drive_init(tb):
+    yield tb.pi.drst_n.eq(1)
+    yield from drive_cs_ca(~0, 0)
+
+
+def drive_cs_ca(cs, ca):
+    yield tb.pi.A_dcs_n.eq(cs)
+    yield tb.pi.A_dca.eq(ca)
+    yield
+
+
+def set_parity(tb):
+    yield tb.pi.A_dpar.eq(reduce(xor, [tb.pi.A_dca[bit] for bit in range(len(tb.pi.A_dca))]))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    # yield from one_ui_dram_command(tb)
+    INIT_CYCLES = CW_DA_REGS_NUM + 5
+    yield from drive_init(tb)
+    for i in range(INIT_CYCLES):
+        yield
+    yield from seq_cmds(tb)
+    for i in range(5):
+        yield
+
+    logging.debug('Yield from write test.')
+
+
+if __name__ == "__main__":
+    eT = EngTest(level=logging.INFO)
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready. Simulating with migen...")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01CoreEgressSimulationPads.py
+++ b/litedram/DDR5RCD01/DDR5RCD01CoreEgressSimulationPads.py
@@ -1,0 +1,90 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM
+from litedram.phy.sim_utils import SimPad, SimulationPads
+# LiteDRAM : RCD
+
+class DDR5RCD01CoreEgressSimulationPads(SimulationPads):
+    """ DDR5 RCD01 Core Egress SimulationPads
+    """
+
+    def layout(self, dcs_n_w=2, dca_w=14, is_dual_channel=False):
+        A_channel = [
+            # Loopback sources
+            ('A_dlbd', 1, False),
+            ('A_dlbs', 1, False),
+            # SDRAM raises an error
+            ('A_derror_in_n', 1, False),
+            # Reset
+            ('A_qrst_n', 1, False),
+            # Adress, Chip Select
+            # Top Row
+            ('A_qacs_a_n', dcs_n_w, False),
+            ('A_qaca_a', dca_w, False),
+            # Bottom Row
+            ('A_qacs_b_n', dcs_n_w, False),
+            ('A_qaca_b', dca_w, False),
+            # Clock outputs
+            # Rank 0, Row Top
+            ('A_qack_t', 1, False),
+            ('A_qack_c', 1, False),
+            # Rank 1, Row Top
+            ('A_qbck_t', 1, False),
+            ('A_qbck_c', 1, False),
+            # Rank 0, Row Bottom
+            ('A_qcck_t', 1, False),
+            ('A_qcck_c', 1, False),
+            # Rank 1, Row Top
+            ('A_qdck_t', 1, False),
+            ('A_qdck_c', 1, False),
+        ]
+        ingress_A_channel = [SimPad(name, size, io)
+                             for name, size, io in A_channel]
+
+        if is_dual_channel:
+            B_channel = [
+                # Loopback sources
+                ('B_dlbd', 1, False),
+                ('B_dlbs', 1, False),
+                # SDRAM raises an error
+                ('B_derror_in_n', 1, False),
+                # Reset
+                ('B_qrst_n', 1, False),
+                # Adress, Chip Select
+                # Top Row
+                ('B_qacs_a_n', dcs_n_w, False),
+                ('B_qaca_a', dca_w, False),
+                # Bottom Row
+                ('B_qacs_b_n', dcs_n_w, False),
+                ('B_qaca_b', dca_w, False),
+                # Clock outputs
+                # Rank 0, Row Top
+                ('B_qack_t', 1, False),
+                ('B_qack_c', 1, False),
+                # Rank 1, Row Top
+                ('B_qbck_t', 1, False),
+                ('B_qbck_c', 1, False),
+                # Rank 0, Row Bottom
+                ('B_qcck_t', 1, False),
+                ('B_qcck_c', 1, False),
+                # Rank 1, Row Top
+                ('B_qdck_t', 1, False),
+                ('B_qdck_c', 1, False),
+            ]
+            ingress_B_channel = [SimPad(name, size, io)
+                                 for name, size, io in B_channel]
+
+        if is_dual_channel:
+            return ingress_A_channel+ingress_B_channel
+        else:
+            return ingress_A_channel
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01CoreIngressSimulationPads.py
+++ b/litedram/DDR5RCD01/DDR5RCD01CoreIngressSimulationPads.py
@@ -1,0 +1,63 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM
+from litedram.phy.sim_utils import SimPad, SimulationPads
+# LiteDRAM : RCD
+
+
+class DDR5RCD01CoreIngressSimulationPads(SimulationPads):
+    """ DDR5 RCD01 Core Ingress SimulationPads
+    """
+
+    def layout(self, dcs_n_w=2, dca_w=7, is_dual_channel=False):
+        common = [
+            # Clock
+            SimPad('dck_t', 1),
+            SimPad('dck_c', 1),
+            # Reset input (Comes from MC)
+            SimPad('drst_n', 1),
+            # Loopback
+            SimPad('qlbd', 1),
+            SimPad('qlbs', 1),
+            # Raise errors
+            SimPad('alert_n', 1),
+        ]
+
+        A_channel = [
+            # Address/Command
+            ('A_dcs_n', dcs_n_w, False),
+            ('A_dca', dca_w, False),
+            # Parity
+            ('A_dpar', 1, False),
+        ]
+
+        ingress_A_channel = [SimPad(name, size, io)
+                             for name, size, io in A_channel]
+
+        if is_dual_channel:
+            B_channel = [
+                # Address/Command
+                ('B_dcs_n', dcs_n_w, False),
+                ('B_dca', dca_w, False),
+                # Parity
+                ('B_dpar', 1, False),
+            ]
+            ingress_B_channel = [SimPad(name, size, io)
+                                 for name, size, io in B_channel]
+        else:
+            ingress_B_channel = []
+
+        if is_dual_channel:
+            return common + ingress_A_channel
+        else:
+            return common + ingress_A_channel + ingress_B_channel
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01DataBuffer.py
+++ b/litedram/DDR5RCD01/DDR5RCD01DataBuffer.py
@@ -1,0 +1,40 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.DDR5RCD01DataBufferChip import DDR5RCD01DataBufferChip
+from litedram.DDR5RCD01.DDR5RCD01DataBufferShell import DDR5RCD01DataBufferShell
+
+class DDR5RCD01DataBuffer(Module):
+    """
+    The DDR5RCD01DataBuffer is a wrapper for the DDR5 data bus. It allows to easily
+    switch from the RDIMM to the LRDIMM implementation with the dimm_type flag.
+    
+    Expected behaviour:
+    RDIMM - data signals are unchanged and passed through
+    LRDIMM - data signals are connected to the DDR5RCD01DataBufferChip object, which
+    may be implemented in the future
+    """
+    def __init__(self, pads_ingress, dimm_type='RDIMM',nranks=1, with_sub_channels=False, **kwargs):        
+        self.submodules.pads_ingress = pads_ingress
+
+        if dimm_type not in ['RDIMM','LRDIMM']:
+            raise('Unsupported DIMM type. Use RDIMM or LRDIMM')
+
+        if dimm_type == 'RDIMM':
+            data_buffer = DDR5RCD01DataBufferShell(pads_ingress)
+        if dimm_type == 'LRDIMM':
+            # TODO replace print with preffered style of logging
+            print('Warning : LRDIMM is not supported')
+            data_buffer = DDR5RCD01DataBufferChip(pads_ingress)
+        
+        self.submodules.data_buffer = data_buffer
+        self.submodules.pads_egress = self.data_buffer.pads_egress
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01DataBufferChip.py
+++ b/litedram/DDR5RCD01/DDR5RCD01DataBufferChip.py
@@ -1,0 +1,16 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+       
+class DDR5RCD01DataBufferChip(Module):
+    def __init__(self, pads_i):        
+        print('LRDIMM Data Buffer not implemented.')
+        # TODO replace print with raise in the final stage of development
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01DataBufferShell.py
+++ b/litedram/DDR5RCD01/DDR5RCD01DataBufferShell.py
@@ -1,0 +1,60 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM : RCD
+from litedram.DDR5RCD01.DDR5RCD01DataBufferSimulationPads import DDR5RCD01DataBufferSimulationPads
+
+class DDR5RCD01DataBufferShell(Module):
+    """
+    DRAM Data bus pass-through
+    """
+    def __init__(self, pads_ingress, nranks=1, with_sub_channels=False, **kwargs):        
+        self.submodules.pads_ingress = pads_ingress
+
+        pads_egress = DDR5RCD01DataBufferSimulationPads(databits=4,
+                                    nranks=nranks,
+                                    dq_dqs_ratio=4,
+                                    with_sub_channels=with_sub_channels)
+        self.submodules.pads_egress = pads_egress
+
+        prefixes = [""] if not with_sub_channels else ["A_", "B_"]
+        
+        # self.comb += (self.pads_egress.dq).eq(self.pads_ingress.dq)
+        # self.comb += (self.pads_egress.cb).eq(self.pads_ingress.cb)
+        # self.comb += (self.pads_egress.dqs_t).eq(self.pads_ingress.dqs_t)
+        # self.comb += (self.pads_egress.dqs_c).eq(self.pads_ingress.dqs_c)
+        connection_matrix_dc = {
+                'dq' : ['dq','Forward'],
+                'cb' : ['cb','Forward'],
+                'dqs_t' : ['dqs_t','Forward'],
+                'dqs_c' : ['dqs_c','Forward'],
+            }
+
+        for prefix in prefixes:
+            for key in connection_matrix_dc:
+                sig_eg = prefix+key
+                sig_in = prefix+connection_matrix_dc[key][0]
+                # Get attr in egress
+                atr_eg = getattr(self.pads_egress, sig_eg)
+                # Get attr in ingress
+                atr_in = getattr(self.pads_ingress, sig_in)
+                # Determine correct direction
+                direction = connection_matrix_dc[key][1]
+                if direction == 'Forward':
+                    print('Connect : ' + sig_in + ' to ' + sig_eg)
+                    self.comb += atr_eg.eq(atr_in)
+                    pass
+                elif direction == 'Reverse':
+                    print('Connect : ' + sig_eg + ' to ' + sig_in)
+                    self.comb += atr_in.eq(atr_eg)
+                    pass
+                else:
+                    raise('Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01DataBufferSimulationPads.py
+++ b/litedram/DDR5RCD01/DDR5RCD01DataBufferSimulationPads.py
@@ -1,0 +1,29 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM
+from litedram.phy.sim_utils import SimPad, SimulationPads
+# LiteDRAM : RCD
+
+class DDR5RCD01DataBufferSimulationPads(SimulationPads):
+    """ The DDR5RCD01DataBufferSimulationPads shall provide SimulationPads 
+    for the DDR5 Data Signals: dq,cb,dqs.
+    Note, the pads are the same for ingress and egress traffic.
+    """
+    def layout(self, databits=8, nranks=1, dq_dqs_ratio=8, with_sub_channels=False):
+        per_channel = [
+            ('dq',32,True),
+            ('cb',8,False),
+            ('dqs_t',8,True),
+            ('dqs_c',8,True),
+        ]
+        channels_prefix = [""] if not with_sub_channels else ["A_", "B_"]
+        return [SimPad(prefix+name, size, io) for prefix in channels_prefix for name, size, io in per_channel]
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01Error.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Error.py
@@ -1,0 +1,82 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01Error(Module):
+    """DDR5 RCD01 Error Alert
+    TODO Documentation
+    Handle the alert signal
+    if parity is enabled, the alert signal is used to raise the parity error
+    if parity is disabled, the alert signal is used to raise the DERROR_IN_n error
+
+    parity check is based on dca and dpar, also it must know whether a true UI is on the line.
+    This is why it may be beneficial to include the parity checker as a separate module.
+    Then the ErrorAlert module will be a simple mux of errors?
+
+    Use case 1. Parity error detected with parity checking enabled
+     - Set CA Parity Error Status (RW24)
+     - Clear bit in RW01 to disable parity checking
+     - Assert ALERT_n for the length 3 input clocks
+
+    RW01.1 
+    This error blocks the pass-through (disable output buffer) until a clear error command!
+    RW01.6
+    Assertion mode
+    RW01.7
+    Parity checking remains ... after pulse
+
+    TODO MVP
+    1. Assert alert if a parity error occured, only block outputs
+    2. Assert alert if a derror_in error occured
+    TODO Full implementation
+    1. Proper register sequence on error
+    2. Add pulse settings and assertion mode supports
+
+    Module
+    ------
+    d - Input : data
+    q - Output: data
+    ------
+    """
+
+    def __init__(self, iif_err, oif_err):
+        # TODO Implement the physical function
+        self.comb += oif_err.err_n.eq(iif_err.err_n)
+
+
+class TestBed(Module):
+    def __init__(self):
+        iif_err = If_error()
+        oif_err = If_error()
+        self.submodules.dut = DDR5RCD01Error(iif_err,oif_err)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(dut):
+    logging.debug('Run test')
+    for i in range(5):
+        yield
+    logging.debug('Yield from run test.')
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01FetchDecode.py
+++ b/litedram/DDR5RCD01/DDR5RCD01FetchDecode.py
@@ -1,0 +1,130 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01FetchDecode(Module):
+    """DDR5 RCD01 
+    TODO this module is a draft, currently unused, untested
+    """
+
+    def __init__(self, if_ib_i, if_ib_o, if_ctrl):
+
+        xfsm_cslogic = FSM(reset_state="RESET")
+        self.submodules += xfsm_cslogic
+
+        deser_latch = Signal(7)
+        deser_en = Signal()
+        xfsm_cslogic.act(
+            "RESET",
+            If(
+                if_ctrl.en,
+                NextState("IDLE")
+            )
+        )
+
+        xfsm_cslogic.act(
+            "IDLE",
+            If(
+                if_ib_i.dcs_n == 0x00,
+                NextValue(deser_latch, if_ib_i.dca),
+                deser_en.eq(1),
+                NextState("S_0a")
+            ).Else(
+                deser_en.eq(0),
+            )
+        )
+        xfsm_cslogic.act(
+            "S_0a",
+            NextValue(deser_latch, if_ib_i.dca),
+            deser_en.eq(1),
+            NextState("S_0b")
+        )
+        xfsm_cslogic.act(
+            "S_0b",
+            NextValue(deser_latch, if_ib_i.dca),
+            deser_en.eq(1),
+            NextState("S_1a")
+        )
+        xfsm_cslogic.act(
+            "S_1a",
+            NextValue(deser_latch, if_ib_i.dca),
+            deser_en.eq(1),
+            NextState("S_1b")
+        )
+        xfsm_cslogic.act(
+            "S_1b",
+            NextValue(deser_latch, if_ib_i.dca),
+            deser_en.eq(0),
+            NextState("IDLE")
+        )
+
+        # Debug information
+        xfsm_debug_state = Signal(4)
+        state_names = ["RESET", "IDLE", "S_0a", "S_0b", "S_1a", "S_1b"]
+        for id, state_name in enumerate(state_names):
+            self.comb += If(xfsm_cslogic.ongoing(state_name),
+                            xfsm_debug_state.eq(id))
+
+
+class TestBed(Module):
+    def __init__(self):
+
+        self.if_ib_i = If_channel_ibuf()
+        self.if_ib_o = If_channel_ibuf()
+        self.if_ctrl = If_ctrl_ibuf()
+
+        self.submodules.dut = DDR5RCD01FetchDecode(
+            if_ib_i=self.if_ib_i, if_ib_o=self.if_ib_o, if_ctrl=self.if_ctrl)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    yield from write_ctrl(tb, 0)
+    yield from behav_write_word(tb, 0x11, 0x00, 0x0)
+    yield from write_ctrl(tb, 1)
+    for i in range(7):
+        yield
+    yield from behav_write_word(tb, 0x00, 0x0a, 0x1)
+    yield from behav_write_word(tb, 0x11, 0x0b, 0x1)
+    yield from behav_write_word(tb, 0x11, 0x1a, 0x1)
+    yield from behav_write_word(tb, 0x11, 0x1b, 0x1)
+    yield from behav_write_word(tb, 0x11, 0x00, 0x0)
+    for i in range(2):
+        yield
+    logging.debug('Yield from write test.')
+
+
+def write_ctrl(tb, d):
+    yield tb.if_ctrl.en.eq(d)
+
+
+def behav_write_word(tb, d_dcs, d_dca, d_dpar):
+    yield tb.if_ib_i.dcs_n.eq(d_dcs)
+    yield tb.if_ib_i.dca.eq(d_dca)
+    yield tb.if_ib_i.dpar.eq(d_dpar)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    raise NotImplementedError("The test of this block is to be done.")
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01InputBuffer.py
+++ b/litedram/DDR5RCD01/DDR5RCD01InputBuffer.py
@@ -1,0 +1,92 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01InputBuffer(Module):
+    """DDR5 RCD01 Input Buffer
+    TODO Review
+    The input buffer comprises:
+      - The analog comparator (with Vref)
+      - DFE, most notably the slicer
+    The analog blocks may only be modelled as delays, however current 
+    implementation is just a pass-through. TODO Add input buffer timing
+    constraints (delays).
+    The output of the input buffer is an equivalent of the "at the slicer 
+    output/after slicer" specification term.
+
+    Module
+    ------
+    if_ib_i - Input interface {dcs_n,dca_n,dpar}
+    if_ib_o - Output interface {dcs_n,dca_n,dpar}
+    if_ctrl - Control interface {en}
+    ------
+    """
+
+    def __init__(self, if_ib_i, if_ib_o, if_ctrl):
+        # Pass-through
+        self.comb += If(if_ctrl.en,
+                        if_ib_o.dcs_n.eq(if_ib_i.dcs_n),
+                        if_ib_o.dca.eq(if_ib_i.dca),
+                        if_ib_o.dpar.eq(if_ib_i.dpar)
+                        ).Else(
+            if_ib_o.dcs_n.eq(0x00),
+            if_ib_o.dca.eq(0x00),
+            if_ib_o.dpar.eq(0x00))
+
+
+class TestBed(Module):
+    def __init__(self):
+        #
+        self.if_ib_i = If_channel_ibuf()
+        self.if_ib_o = If_channel_ibuf()
+        self.if_ctrl = If_ctrl_ibuf()
+        ###
+        self.submodules.dut = DDR5RCD01InputBuffer(
+            if_ib_i=self.if_ib_i, if_ib_o=self.if_ib_o, if_ctrl=self.if_ctrl)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    yield from behav_write_word(0x00, 0x00, 0x0)
+    yield from behav_write_word(0x01, 0x01, 0x1)
+    yield from write_ctrl(1)
+    yield from behav_write_word(0x02, 0x02, 0x0)
+    yield from behav_write_word(0x03, 0x03, 0x0)
+    yield from behav_write_word(0x00, 0x04, 0x1)
+
+    logging.debug('Yield from write test.')
+
+
+def write_ctrl(d):
+    yield tb.if_ctrl.en.eq(d)
+
+
+def behav_write_word(d_dcs, d_dca, d_dpar):
+    yield tb.if_ib_i.dcs_n.eq(d_dcs)
+    yield tb.if_ib_i.dca.eq(d_dca)
+    yield tb.if_ib_i.dpar.eq(d_dpar)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01LineBuffer.py
+++ b/litedram/DDR5RCD01/DDR5RCD01LineBuffer.py
@@ -1,0 +1,317 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+from random import randrange
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_utils import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+
+
+class DDR5RCD01LineBuffer(Module):
+    """DDR5 RCD01 Line Buffer
+    TODO Documentation
+    This module servers 3 purposes:
+      1. Deserialize the 2UI into 1 UI
+      2. Model the latency from the input buffer to the output buffer. It's a constant delay
+      is estimated from:
+        - analog input buffer delay
+        - time required for internal control, register file accesses, etc.
+        - analog output buffer delay
+      Currently, rcd_t_prop_delay_nck is set to 1, but this may be a subject of change.
+      3. Latency Equalization Support
+      Model the latency equalization, which is a programmable feature of additionally
+      delaying the output by nCK, n={0,1,2,3,4}
+
+    Module
+    ------
+    d               - Input interface {dcs_n, dca_n}
+    q               - Output interface {qcs_n, qca_n}
+    c               - Config interface {sel_latency_add}
+
+    sel_latency_add - Input : Select added latency (3 bits should be enough)
+    ------
+    Parameters
+    rcd_t_prop_delay_nck : Constant time delay, expressed in clock periods
+      Expected value : 1
+                 Min : 1
+                 Max : n/a
+    rcd_t_eq_latency_nck_max : Maximum value of programmable time
+    delay (latency equalization), expressed in clock periods
+      Expected value : 4
+    """
+
+    def __init__(self, if_i, if_o, if_ctrl, rcd_t_prop_delay_nck=1, rcd_t_eq_latency_nck_max=4):
+
+        len_dcs_n = len(if_i.dcs_n)
+        len_dca = len(if_i.dca)
+        len_qca = 2*len_dca
+
+        # Deserializer
+        # TODO Should The Deserializer also perform the dcs sync for different modes SDR,DDR??
+        deser_qca = Signal(len_qca)
+        deser_qcs_n = Signal(len_dcs_n)
+        xdeser_dca = Deserializer_2_to_1(d=if_i.dca,
+                                         d_en=if_ctrl.deser_ca_d_en,
+                                         q=deser_qca,
+                                         q_en=if_ctrl.deser_ca_q_en,
+                                         sel=if_ctrl.deser_sel_lower_upper)
+        self.submodules += xdeser_dca
+
+        xdeser_dcs_n = Deserializer_2_to_1(d=if_i.dcs_n,
+                                           d_en=if_ctrl.deser_cs_n_d_en,
+                                           q=deser_qcs_n,
+                                           q_en=if_ctrl.deser_cs_n_q_en,
+                                           sel=0)
+
+        self.submodules += xdeser_dcs_n
+
+        # TODO Check if both ranks get the same values
+
+        # d_const_delay = Array(Signal(len_dcs_n)
+        #                       for y in range(rcd_t_prop_delay_nck))
+        # Static delay
+        sta_qcs_n = Signal(len_dcs_n)
+        static_delay_qcs = StaticDelay(
+            d=deser_qcs_n, q=sta_qcs_n, delay=rcd_t_prop_delay_nck)
+        self.submodules.static_delay_qcs = static_delay_qcs
+
+        sta_qca = Signal(len_qca)
+        static_delay_qca = StaticDelay(
+            deser_qca, sta_qca, delay=rcd_t_prop_delay_nck)
+        self.submodules.static_delay_qca = static_delay_qca
+
+        # Programmable delay
+        prog_qcs_n = Signal(len_dcs_n)
+        prog_delay_qcs = ProgDelay(
+            sta_qcs_n, prog_qcs_n, if_ctrl.sel_latency_add, delay_prog_max=rcd_t_eq_latency_nck_max)
+        self.submodules.prog_delay_qcs = prog_delay_qcs
+
+        prog_qca = Signal(len_qca)
+        prog_delay_qca = ProgDelay(
+            sta_qca, prog_qca, if_ctrl.sel_latency_add, delay_prog_max=rcd_t_eq_latency_nck_max)
+        self.submodules.prog_delay_qca = prog_delay_qca
+        # breakpoint()
+
+        self.comb += if_o.qacs_a_n.eq(prog_qcs_n)
+        self.comb += if_o.qaca_a.eq(prog_qca)
+
+        self.comb += if_o.qacs_b_n.eq(prog_qcs_n)
+        self.comb += if_o.qaca_b.eq(prog_qca)
+
+
+class Deserializer_2_to_1(Module):
+    """
+    The incoming stream of DCAs of width 7 must be serialized into 14 bits, c.f. Table 8
+    UI DCA0 DCA1 DCA2 DCA3 DCA4 DCA5 DCA6
+    0  QCA0 QCA1 QCA2 QCA3 QCA4 QCA5 QCA6
+    1  QCA7 QCA8 QCA9 QCAA QCAB QCAC QCAD
+
+    First UI (number 0) goes to the lower part of the word QCA[6:0]
+    Second UI (number 1) goes to the upper part of the word QCA[13:7]
+
+    DCA -> Demux -> D -> D--> QCA[6:0]
+                 -> D ------> QCA[13:7]
+    Module
+    ------
+    d - input
+    sel_lower_upper - Select where the word goes
+    q - output
+
+    Parameters
+    ----------
+    d_w - bit width of d
+
+    Local Parameters
+    ---------------
+    q_w - Assumed double the width of d_w
+    """
+
+    def __init__(self, d, d_en, q, q_en, sel, d_w=7):
+
+        d_lower = Signal(d_w)
+        d_upper = Signal(d_w)
+
+        self.sync += If(
+            d_en,
+            If(sel,
+                d_upper.eq(d),
+               ).Else(
+                d_lower.eq(d)
+            )
+        )
+
+        self.sync += If(
+            q_en,
+            q.eq(Cat(d_lower, d_upper))
+        ).Else(
+            If(~d_en,
+               q.eq(~0)
+               )
+        )
+
+
+class StaticDelay(Module):
+    """
+    Q signal is the D signal delayed by 'delay' clocks
+
+    Module
+    ------
+    d - input
+    q - output
+
+    Parameters
+    ----------
+    delay - number of clocks to delay
+    """
+
+    def __init__(self, d, q, delay=1):
+        len_d = len(d)
+        d_const_delay = Array(Signal(len_d) for y in range(delay))
+        # rcd_t_prop_delay is modelled with a set of series registers
+        # d-d-d-d-d-...-d
+        debug_string = "In --> "
+        for i in range(delay):
+            debug_string = debug_string + " [D] --> "
+            if i == 0:
+                self.sync += d_const_delay[0].eq(d)
+            else:
+                self.sync += d_const_delay[i].eq(d_const_delay[i-1])
+        debug_string = debug_string + " q_int --> mux_i "
+        logging.debug(debug_string)
+        # Last register is then at index rcd_t_prop_delay_nck-1
+        id_last = delay-1
+        # Drive output
+        self.comb += q.eq(d_const_delay[id_last])
+
+
+class ProgDelay(Module):
+    """
+    Programmable delay
+    Create a path for each delayed signal?
+    0-4 possible outputs
+    """
+
+    def __init__(self, d, q, sel_latency_add, delay_prog_max=4):
+
+        d_prog_delay_num = delay_prog_max+1
+        len_d = len(d)
+        mux_i = Array(Signal(len_d) for y in range(d_prog_delay_num))
+
+        for i in range(d_prog_delay_num):
+            logging.debug("%d-delay path", i)
+            debug_string = "mux_i --> "
+            d_prog_delay = Array(Signal(len_d) for y in range(i))
+            if i == 0:
+                self.comb += mux_i[i].eq(d)
+            for j in range(i):
+                debug_string = debug_string + " [D]int_"+str(j)+" --> "
+                # Connect the first signal
+                if j == 0:
+                    self.sync += d_prog_delay[0].eq(d)
+                # Series connect
+                else:
+                    self.sync += d_prog_delay[j].eq(d_prog_delay[j-1])
+                # Connect to the mux
+                if j == (i-1):
+                    self.comb += mux_i[i].eq(d_prog_delay[j])
+            debug_string = debug_string + " --> mux_o "
+            logging.debug(debug_string)
+        # Create a dictionary: mux_select: mux_inputs
+        mux_dict = {}
+        mux_o = Signal(len_d)
+        for i in range(d_prog_delay_num):
+            mux_dict[i] = mux_o.eq(mux_i[i])
+        self.comb += Case(sel_latency_add, mux_dict)
+        self.comb += q.eq(mux_o)
+
+
+class TestBed(Module):
+    def __init__(self):
+        
+        self.ctrl_if = If_ctrl_lbuf()
+        self.iif = If_channel_ibuf()
+        self.oif = If_channel_obuf_csca()
+
+        self.submodules.dut = DDR5RCD01LineBuffer(
+            self.iif, self.oif, self.ctrl_if)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(dut):
+    logging.debug('Write test')
+    yield from behav_rst()
+    pattern_dcs = [0x00, 0x01, 0x02, 0x03, 0x00]
+    pattern_dca = [0x5A, 0xA5, 0x0A, 0x0B, 0x0C]
+    pattern = list(zip(pattern_dcs, pattern_dca))
+    logging.debug("Test [DCS,DCA] pattern: " + str(pattern))
+    yield
+    yield from write_set_pattern(pattern)
+    yield
+    yield from write_random_pattern()
+    yield
+    yield from sweep_mux()
+    yield
+    logging.debug('Yield from write test.')
+
+
+def behav_rst():
+    yield tb.iif.dcs_n.eq(1)
+    yield tb.iif.dca.eq(0)
+    yield tb.ctrl_if.sel_latency_add.eq(0)
+    yield tb.ctrl_if.deser_sel_lower_upper.eq(0)
+    yield tb.ctrl_if.deser_ca_d_en.eq(0)
+    yield tb.ctrl_if.deser_ca_q_en.eq(0)
+
+
+def behav_write_word(dcs_n, dca_n):
+    yield tb.iif.dcs_n.eq(dcs_n)
+    yield tb.iif.dca.eq(dca_n)
+    yield
+
+
+def write_random_pattern():
+    bits = [randrange(2) for y in range(10)]
+    logging.debug('random pattern = '+str(bits))
+    for bit in bits:
+        yield from behav_write_word(bit, bit)
+
+
+def write_set_pattern(pattern):
+    even = True
+    for word_dcs, word_dca in pattern:
+        yield tb.ctrl_if.deser_ca_d_en.eq(1)
+        yield tb.ctrl_if.deser_ca_q_en.eq(1)
+        if even:
+            yield tb.ctrl_if.deser_sel_lower_upper.eq(0)
+        else:
+            yield tb.ctrl_if.deser_sel_lower_upper.eq(1)
+        even = not even
+
+        yield from behav_write_word(word_dcs, word_dca)
+        yield tb.ctrl_if.deser_ca_d_en.eq(0)
+        yield tb.ctrl_if.deser_ca_q_en.eq(0)
+
+
+def sweep_mux(rcd_t_eq_latency_nck_max=4):
+    for i in range(rcd_t_eq_latency_nck_max+1):
+        yield tb.ctrl_if.sel_latency_add.eq(i)
+        yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01Loopback.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Loopback.py
@@ -1,0 +1,198 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_utils import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+
+
+class DDR5RCD01Loopback(Module):
+    """DDR5 RCD01 Loopback
+    TODO Documentation
+    In order to enable loopback RW26 word must be set (select input).
+    DFE Training Mode should not be used simultaneously
+
+    transitions in the incoming data signal are aligned to the rising od the incoming strobe
+    rcd will sample incoming data with the falling edge of the incoming strobe
+    rcd will apply logic inversion in the outgoing strobe signal
+    c.f figure 20
+
+    RW26.0-2 select input source (external or internal)
+
+    [EXTERNAL] RW26.6 signals are 1/4 or 1/2 rate
+    The host is responsible for generation of these signals and timing requirements.
+    I could not find explicit information on how these are generated. The remark
+    'signals are 1/4 or 1/2 rate' is understood to mean 'the strobe and data signals
+    are generated in the dck_t(c) domain at every other (every 4th) positive edge'
+    As such if the loopback module uses the dck_t(c) signals we know the relationship
+    betweend strobe signal and dck_t. They are aligned?
+
+
+    [INTERNAL] RW26.3-5 internal RCD bit selection
+    In the internal use case select which signal (dca0, dca1, ..., dca7, dpar) is selected
+    Case(RW26.3-5, 0, d = dca0; 1, d = dca1;...)
+    Signals dca,dpar are taken from the DFE slicer
+
+    [INTERNAL] RW26.7 Phase select - A or B
+    What is a phase? Phase select whether the signal is aligned with dck_t or dck_c
+    PHASE_A => dck_t
+    PHASE_B => dck_c
+    Internal loopback uses the 'line' dck, not from PLL
+    Internal use case is fixed at 1/2 rate.
+
+    Module
+    ------
+    Inputs : possible sources of loopback. All ports come in pairs (data,strobe)
+    [EXTERNAL USE CASE]
+    dlbd_a, dlbs_a             - Channel A data and strobe
+    dlbd_b, dlbs_b             - Channel B data and strobe
+    [INTERNAL USE CASE]
+    cha_dca_dfe, cha_dpar_dfe  - Channel A DFE Circuit data
+    dck_t, dck_c               - Clock inputs are the strobes for the internal use case
+    chb_dca_dfe, chb_dpar_dfe  - Channel B DFE Circuit data
+    [CONFIG, c.f. RW26]
+    sel_mode - Select disable,internal,external, A or B channel
+    sel_phase_ab - Select phase (A or B)
+    sel_int_bit - Select internal bit (DCA[6:0] or DPAR)
+
+
+    Outputs: loopback data.
+    qlbd_ab, qlbs_ab      - Loopback output data and strobe
+
+    ------
+    Parameters
+    TIE_VALUE = {TIE_LOW, TIE_HIGH}. Should be evaluated to const 0 or const 1.
+    TODO determine if i/o timings are to be kept in the model
+    tDCK2QLBS - time delay from input to output. (migen can't evaluate it)
+    """
+
+    """
+  @(negedge strobe)
+    data <= d_in
+  """
+
+    def __init__(self,
+                 if_ck,
+                 if_host_lb,
+                 if_rcd_lb,
+                 if_sdram_A_lb,
+                 if_sdram_B_lb,
+                 if_channel_A_dfe_lb,
+                 if_channel_B_dfe_lb,
+                 if_ctrl_lb):
+
+        #
+        # Internal path
+        #
+
+        int_da = Signal()
+        int_db = Signal()
+        # Mux : select bit
+        # breakpoint()
+        self.comb += Case(if_ctrl_lb.sel_int_bit, {0: int_da.eq(if_channel_A_dfe_lb.dca_lb[0]),
+                                                   1: int_da.eq(if_channel_A_dfe_lb.dca_lb[1]),
+                                                   2: int_da.eq(if_channel_A_dfe_lb.dca_lb[2]),
+                                                   3: int_da.eq(if_channel_A_dfe_lb.dca_lb[3]),
+                                                   4: int_da.eq(if_channel_A_dfe_lb.dca_lb[4]),
+                                                   5: int_da.eq(if_channel_A_dfe_lb.dca_lb[5]),
+                                                   6: int_da.eq(if_channel_A_dfe_lb.dca_lb[6]),
+                                                   7: int_da.eq(if_channel_A_dfe_lb.dpar_lb)}
+                          )
+        self.comb += Case(if_ctrl_lb.sel_int_bit, {0: int_db.eq(if_channel_B_dfe_lb.dca_lb[0]),
+                                                   1: int_db.eq(if_channel_B_dfe_lb.dca_lb[1]),
+                                                   2: int_db.eq(if_channel_B_dfe_lb.dca_lb[2]),
+                                                   3: int_db.eq(if_channel_B_dfe_lb.dca_lb[3]),
+                                                   4: int_db.eq(if_channel_B_dfe_lb.dca_lb[4]),
+                                                   5: int_db.eq(if_channel_B_dfe_lb.dca_lb[5]),
+                                                   6: int_db.eq(if_channel_B_dfe_lb.dca_lb[6]),
+                                                   7: int_db.eq(if_channel_B_dfe_lb.dpar_lb)}
+                          )
+
+        # Mux : select phase for internal
+        phase_ck = Signal()
+        self.comb += If(if_ctrl_lb.sel_phase_ab == 1,
+                        phase_ck.eq(if_ck.ck_t)
+                        ).Else(phase_ck.eq(if_ck.ck_c))
+
+        # Mux : select A or B channel
+        int_d = Signal()
+        self.comb += If(if_ctrl_lb.sel_mode == 1,
+                        int_d.eq(int_da)
+                        ).Elif(if_ctrl_lb.sel_mode == 2,
+                               int_d.eq(int_db)
+                               ).Else(int_d.eq(0))
+        # TODO Change domain of this sync to phase_ck
+        int_dd = Signal()
+        self.sync += int_dd.eq(int_d)
+
+        # External path
+
+        # Mux between internal and external
+        self.comb += Case(if_ctrl_lb.sel_mode, {0: [if_rcd_lb.lbs.eq(TIE_LOW),
+                                                    if_rcd_lb.lbd.eq(TIE_LOW)],
+                                                1: [if_rcd_lb.lbs.eq(if_ck.ck_t),
+                                                    if_rcd_lb.lbd.eq(int_dd)],
+                                                2: [if_rcd_lb.lbs.eq(if_ck.ck_c),
+                                                    if_rcd_lb.lbd.eq(int_dd)],
+                                                3: [if_rcd_lb.lbs.eq(0),
+                                                    if_rcd_lb.lbd.eq(0)],
+                                                4: [if_rcd_lb.lbs.eq(0),
+                                                    if_rcd_lb.lbd.eq(0)],
+                                                5: [if_rcd_lb.lbs.eq(0),
+                                                    if_rcd_lb.lbd.eq(0)],
+                                                })
+
+
+class TestBed(Module):
+    def __init__(self):
+        #
+        self.if_ck = If_ck()
+        self.if_host_lb = If_lb()
+        self.if_rcd_lb = If_lb()
+        self.if_sdram_A_lb = If_lb()
+        self.if_sdram_B_lb = If_lb()
+        self.if_channel_A_dfe_lb = If_int_lb()
+        self.if_channel_B_dfe_lb = If_int_lb()
+        self.if_ctrl_lb = If_ctrl_lb()
+        ###
+        self.submodules.dut = DDR5RCD01Loopback(self.if_ck,
+                                               self.if_host_lb,
+                                               self.if_rcd_lb,
+                                               self.if_sdram_A_lb,
+                                               self.if_sdram_B_lb,
+                                               self.if_channel_A_dfe_lb,
+                                               self.if_channel_B_dfe_lb,
+                                               self.if_ctrl_lb)
+        # print(verilog.convert(self.lb))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    yield from behav_write_word(0x0)
+
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(tb):
+    #
+    # yield dut.d.eq(data)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01OutputBuffer.py
+++ b/litedram/DDR5RCD01/DDR5RCD01OutputBuffer.py
@@ -1,0 +1,189 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_utils import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+
+
+class DDR5RCD01OutputBuffer(Module):
+    """DDR5 RCD01 Output Buffer
+    TODO Documentation
+    d         - Input : data
+    oe        - Input : output enable
+    o_inv_en  - Input : output inversion enable
+    frac_p    - Input : Fractional (n/64) phase delay select; frac_p==0 -> no delay
+    q         - Output: data
+    # Driver strength is not on implementation list, also: slew rate control
+    """
+
+    def __init__(self, if_i_csca, if_i_clks, if_o_csca, if_o_clks, if_ctrl, sig_disable_level=1):
+        # Hook inputs
+
+        # Output
+        # Top Row QACS QACA
+        xoutbuf_qacs_a_n = OutBuf(if_i_csca.qacs_a_n, if_o_csca.qacs_a_n, if_ctrl.oe_qacs_a_n,
+                                  if_ctrl.o_inv_en_qacs_a_n,  sig_disable_level=1)
+        self.submodules += xoutbuf_qacs_a_n
+        xoutbuf_qaca_a = OutBuf(if_i_csca.qaca_a, if_o_csca.qaca_a,
+                                if_ctrl.oe_qaca_a, if_ctrl.o_inv_en_qaca_a)
+        self.submodules += xoutbuf_qaca_a
+        # Bottom Row
+        xoutbuf_qacs_b_n = OutBuf(if_i_csca.qacs_b_n, if_o_csca.qacs_b_n, if_ctrl.oe_qacs_b_n,
+                                  if_ctrl.o_inv_en_qacs_b_n,  sig_disable_level=1)
+        self.submodules += xoutbuf_qacs_b_n
+        xoutbuf_qaca_b = OutBuf(if_i_csca.qaca_b, if_o_csca.qaca_b,
+                                if_ctrl.oe_qaca_b, if_ctrl.o_inv_en_qaca_b)
+        self.submodules += xoutbuf_qaca_b
+
+        # Clock A
+        xoutbuf_qack_t = OutBuf(if_i_clks.qack_t, if_o_clks.qack_t,
+                                if_ctrl.oe_qack_t, if_ctrl.o_inv_en_qack_t)
+        self.submodules += xoutbuf_qack_t
+        xoutbuf_qack_c = OutBuf(if_i_clks.qack_c, if_o_clks.qack_c,
+                                if_ctrl.oe_qack_c, if_ctrl.o_inv_en_qack_c)
+        self.submodules += xoutbuf_qack_c
+        # Clock B
+        xoutbuf_qbck_t = OutBuf(if_i_clks.qbck_t, if_o_clks.qbck_t,
+                                if_ctrl.oe_qbck_t, if_ctrl.o_inv_en_qbck_t)
+        self.submodules += xoutbuf_qbck_t
+        xoutbuf_qbck_c = OutBuf(if_i_clks.qbck_c, if_o_clks.qbck_c,
+                                if_ctrl.oe_qbck_c, if_ctrl.o_inv_en_qbck_c)
+        self.submodules += xoutbuf_qbck_c
+        # Clock C
+        xoutbuf_qcck_t = OutBuf(if_i_clks.qcck_t, if_o_clks.qcck_t,
+                                if_ctrl.oe_qcck_t, if_ctrl.o_inv_en_qcck_t)
+        self.submodules += xoutbuf_qcck_t
+        xoutbuf_qcck_c = OutBuf(if_i_clks.qcck_c, if_o_clks.qcck_c,
+                                if_ctrl.oe_qcck_c, if_ctrl.o_inv_en_qcck_c)
+        self.submodules += xoutbuf_qcck_c
+        # Clock D
+        xoutbuf_qdck_t = OutBuf(if_i_clks.qdck_t, if_o_clks.qdck_t,
+                                if_ctrl.oe_qdck_t, if_ctrl.o_inv_en_qdck_t)
+        self.submodules += xoutbuf_qdck_t
+        xoutbuf_qdck_c = OutBuf(if_i_clks.qdck_c, if_o_clks.qdck_c,
+                                if_ctrl.oe_qdck_c, if_ctrl.o_inv_en_qdck_c)
+        self.submodules += xoutbuf_qdck_c
+
+        # TODO Implement fractional delay here
+        # If frac_p == xx, delay the clock by yy
+
+
+class OutBuf(Module):
+    """ TODO documentation
+    """
+
+    def __init__(self, d, q, oe, o_inv_en, sig_disable_level=0):
+        self.comb += If(oe,
+                        If(o_inv_en,
+                           q.eq(~d)
+                           ).Else(q.eq(d))
+                        ).Else(q.eq(sig_disable_level))
+
+
+class TestBed(Module):
+    def __init__(self):
+
+        self.ctrl_if = If_ctrl_obuf()
+        self.iif_csca = If_channel_obuf_csca()
+        self.iif_clks = If_channel_obuf_clks()
+        self.oif_csca = If_channel_obuf_csca()
+        self.oif_clks = If_channel_obuf_clks()
+
+        self.submodules.dut = DDR5RCD01OutputBuffer(
+            self.iif_csca, self.iif_clks, self.oif_csca, self.oif_clks, self.ctrl_if)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(dut):
+    logging.debug('Write test')
+    yield from behav_rst(tb)
+    yield
+    yield from set_all_outs(tb, 1)
+    yield
+    yield from set_all_outs(tb, 0)
+    yield
+    yield from set_all_oe(tb, 1)
+    yield
+    yield from set_all_outs(tb, 1)
+    yield
+    yield from set_all_outs(tb, 0)
+    yield
+    yield from set_all_inv_en(tb, 1)
+    yield
+    yield from set_all_outs(tb, 1)
+    yield
+    yield from set_all_outs(tb, 0)
+    yield
+
+    logging.debug('Yield from write test.')
+
+
+def set_all_inv_en(tb, b):
+    yield tb.ctrl_if.o_inv_en_qacs_a_n.eq(b)
+    yield tb.ctrl_if.o_inv_en_qaca_a.eq(b)
+    yield tb.ctrl_if.o_inv_en_qacs_b_n.eq(b)
+    yield tb.ctrl_if.o_inv_en_qaca_b.eq(b)
+    yield tb.ctrl_if.o_inv_en_qack_t.eq(b)
+    yield tb.ctrl_if.o_inv_en_qack_c.eq(b)
+    yield tb.ctrl_if.o_inv_en_qbck_t.eq(b)
+    yield tb.ctrl_if.o_inv_en_qbck_c.eq(b)
+    yield tb.ctrl_if.o_inv_en_qcck_t.eq(b)
+    yield tb.ctrl_if.o_inv_en_qcck_c.eq(b)
+    yield tb.ctrl_if.o_inv_en_qdck_t.eq(b)
+    yield tb.ctrl_if.o_inv_en_qdck_c.eq(b)
+
+
+def set_all_oe(tb, b):
+    yield tb.ctrl_if.oe_qacs_a_n.eq(b)
+    yield tb.ctrl_if.oe_qaca_a.eq(b)
+    yield tb.ctrl_if.oe_qacs_b_n.eq(b)
+    yield tb.ctrl_if.oe_qaca_b.eq(b)
+    yield tb.ctrl_if.oe_qack_t.eq(b)
+    yield tb.ctrl_if.oe_qack_c.eq(b)
+    yield tb.ctrl_if.oe_qbck_t.eq(b)
+    yield tb.ctrl_if.oe_qbck_c.eq(b)
+    yield tb.ctrl_if.oe_qcck_t.eq(b)
+    yield tb.ctrl_if.oe_qcck_c.eq(b)
+    yield tb.ctrl_if.oe_qdck_t.eq(b)
+    yield tb.ctrl_if.oe_qdck_c.eq(b)
+
+
+def set_all_outs(tb, b):
+    yield tb.iif_csca.qacs_a_n.eq(b)
+    yield tb.iif_csca.qaca_a.eq(b)
+    yield tb.iif_csca.qacs_b_n.eq(b)
+    yield tb.iif_csca.qaca_b.eq(b)
+    yield tb.iif_clks.qack_t.eq(b)
+    yield tb.iif_clks.qack_c.eq(b)
+    yield tb.iif_clks.qbck_t.eq(b)
+    yield tb.iif_clks.qbck_c.eq(b)
+    yield tb.iif_clks.qcck_t.eq(b)
+    yield tb.iif_clks.qcck_c.eq(b)
+    yield tb.iif_clks.qdck_t.eq(b)
+    yield tb.iif_clks.qdck_c.eq(b)
+
+
+def behav_rst(tb):
+    yield from set_all_inv_en(tb, 0)
+    yield from set_all_oe(tb, 0)
+    yield from set_all_outs(tb, 0)
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01PLL.py
+++ b/litedram/DDR5RCD01/DDR5RCD01PLL.py
@@ -1,0 +1,76 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+import logging
+# migen
+from migen import *
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+class DDR5RCD01PLL(Module):
+    """DDR5 RCD01 PLL
+    TODO Documentation
+    RW05 dimm operating speed, frequency band select - test mode?
+    RW06 defines the dck input clock frequency
+    Do I need the x64 clock to generate fractions n/64?
+    Is the main function of PLL in physical implementation to re-drive the clock?
+    Then, in the model it wouldn't have to do much
+    TODO current implementation is a bypass mode only (RW05.3-0 == 1111)
+    Module
+    ------
+    dck_t,dck_c : Input clock
+    qck_t,qck_c : Output clock (x1); for every rank, row, etc.
+    qck64_t,qck64_c : Output clock (x64)
+
+    """
+
+    def __init__(self, iif, oif_A, oif_B, ctrl_if):
+        # Just a clock pass-through
+        self.comb += oif_A.ck_t.eq(iif.ck_t)
+        self.comb += oif_A.ck_c.eq(iif.ck_c)
+        
+        self.comb += oif_B.ck_t.eq(iif.ck_t)
+        self.comb += oif_B.ck_c.eq(iif.ck_c)
+        
+        # TODO Replace with a real PLL model
+        # TODO Implement control interface handler
+
+
+class TestBed(Module):
+    def __init__(self):
+        
+        self.iif = If_ck()
+        self.oif_A = If_ck()
+        self.oif_B = If_ck()
+        self.ctrl_if = If_ctrl_pll()
+        self.comb += self.iif.ck_c.eq(~self.iif.ck_t)
+        
+        self.submodules.dut = DDR5RCD01PLL(self.iif, self.oif_A, self.oif_B, self.ctrl_if)
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    for b in [0, 1]*5:
+        yield from behav_write(b)
+    logging.debug('Yield from write test.')
+
+
+def behav_write(b):
+    yield tb.iif.ck_t.eq(b)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01Page.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Page.py
@@ -1,0 +1,137 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+from reprlib import *
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01Page(Module):
+    """DDR5 RCD01 Page
+    TODO Documentation
+      In an RCD, there are 256 pages. A page is a set of 32 registers.
+      The page pointer is held in the RW5F.
+
+    """
+
+    def pretty_print(self):
+        """ Prints current value of registers and their metadata
+        """
+        repack = Repr()
+        repack.maxstring = 20
+        line = '-'*80
+        logging.debug(line)
+        logging.debug('Page')
+        logging.debug(line+'0x00')
+        logging.debug("Signal "+"value "+"name "+"address " +
+                      "description "+"global "+"attribute ")
+        for id, meta in enumerate(self.registers_metadata):
+            reg = self.registers[id]
+            str_format = repack.repr(str(reg))+' | '
+            reg_val = (yield reg)
+            str_format = str_format + str(reg_val)+' | '
+            for m in meta:
+                # TODO Fix the global flag print
+                str_format = str_format + repack.repr(str(m)) + ' | '
+            logging.debug(str_format)
+            # TODO Fix
+            # This if-statement is here to prevent very long prints
+            # Repr can be used to limit the list output
+            if id == 5:
+                break
+        logging.debug(line+'0x05')
+
+    def load_page_def(self, page_id=0):
+        """ Loads string data from RCD_definitions.py to an object regsiters_metadata
+        """
+        logging.debug('Reading information in page ' +
+                      str(page_id) + ' definition')
+        self.registers_metadata = []
+        prefix = "rcd_page_"
+        string_name = prefix+str(page_id)
+        table_handle = rcd_pages[string_name]
+        for id, msg in enumerate(table_handle):
+            self.registers_metadata.append(msg)
+
+    def __init__(self, d, addr, we):
+        # Register file
+        self.registers = Array(Signal(CW_REG_BIT_SIZE)
+                               for y in range(CW_PAGE_PTRS_NUM))
+        logging.debug('Created Page: %d x %db', len(
+            self.registers), len(self.registers[0]))
+
+        # Attribute registers
+        # Attribute regs are created in a weird way now.
+        # TODO fix attr regs, they should be embedded
+        # attr_regs = AttributeRegs()
+        # self.submodules.attr_regs = attr_regs
+
+        # Output of a page are all registers at the same time.
+
+        # Create da_regs_metadata
+        self.load_page_def()
+
+        for id, reg in enumerate(self.registers):
+            self.sync += If(we,
+                            If(addr == id,
+                                self.registers[id].eq(d)
+                               )
+                            )
+            # read_only is 2, need to replace this
+            # If( self.attr_regs.attr_regs[id][2] == 0,
+            # self.registers[id].eq(d) )
+            # )
+
+
+class TestBed(Module):
+    def __init__(self):
+
+        self.we = Signal()
+        self.d = Signal(CW_REG_BIT_SIZE)
+        self.addr = Signal(8)
+        self.submodules.dut = DDR5RCD01Page(
+            we=self.we, addr=self.addr, d=self.d)
+        # print(verilog.convert(self.regfile))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+
+    yield from tb.dut.pretty_print()
+    yield from behav_write_word(tb, 0x23, 0x00)
+    yield from behav_write_word(tb, 0x24, 0x01)
+    yield from behav_write_word(tb, 0x25, 0x03)
+    yield from behav_write_word(tb, 0x26, 0x0A)
+    for i in range(3):
+        yield
+
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(tb, data, addr):
+    yield tb.d.eq(data)
+    yield tb.addr.eq(addr)
+    yield tb.we.eq(1)
+    yield
+    yield tb.we.eq(0)
+    yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01Pages.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Pages.py
@@ -1,0 +1,118 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+from reprlib import *
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.DDR5RCD01Page import *
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+from litedram.DDR5RCD01.RCD_utils import *
+
+
+class DDR5RCD01Pages(Module):
+    """DDR5 RCD01 Pages
+    TODO Documentation
+      In an RCD, there are 256 pages. A page is a set of 32 registers.
+      The page pointer is held in the RW5F.
+
+      Module
+      ------
+      d - input, a whole page
+      we - write enable to override whole page
+      page_pointer - connect to RW5F, selects page from 0 to 255
+      q_page -
+    """
+
+    def __init__(self, d, we, page_pointer, q_page, page_addr, cw_page_num = CW_PAGE_NUM):
+        # Hook inputs
+        # Page file
+        self.pages = Array(DDR5RCD01Page(d, page_addr, we)
+                           for y in range(cw_page_num))
+        logging.debug('Created Pages: %d', len(self.pages))
+        #
+        # TODO Initialize
+
+        # PAGES
+        # foreach page
+        for id, page in enumerate(self.pages):
+            # foreach register in page
+            for id_r, reg in enumerate(page.registers):
+                # d is a page, which overwrites currently stored page
+                # breakpoint()
+                self.sync += If(we == 1,
+                                If(page_pointer == id,
+                                   If(page_addr == id_r,
+                                      self.pages[id].registers[id_r].eq(d)
+                                      )
+                                   )
+                                )
+        # OUTPUT
+        # q_pages is an output, which present a page currently selected by the page pointer
+        # self.q_pages = Array(Signal(CW_REG_BIT_SIZE)
+        #                      for y in range(CW_PAGE_PTRS_NUM))
+        # for id_r, reg in enumerate(q_pages):
+        #     self.comb += q_pages[id_r].eq(
+        #         (self.pages[page_pointer]).registers[id_r])
+        # breakpoint()
+        # foreach register in page
+        for id_r, reg in enumerate(page.registers):
+            self.comb += q_page[id_r].eq(
+                self.pages[page_pointer].registers[id_r])
+
+
+class TestBed(Module):
+    def __init__(self):
+        # TODO fix the scenario
+        raise NotImplementedError("This test is to be done.")
+        self.we = Signal()
+        self.d = Array(Signal(CW_REG_BIT_SIZE)
+                       for y in range(CW_PAGE_PTRS_NUM))
+        self.page_pointer = Signal(8)
+        self.q_page = Signal()
+        self.page_addr = Signal()
+        self.submodules.pages = DDR5RCD01Pages(
+            we=self.we, d=self.d, page_pointer=self.page_pointer, q_page=self.q_page, page_addr=self.page_addr)
+
+        # print(verilog.convert(self.regfile))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    yield from tb.dut.regfile.pretty_print()
+    yield from behav_write_word(0x23, 0x00)
+    yield from behav_write_word(0x24, 0x01)
+    yield from behav_write_word(0x25, 0x03)
+    yield from behav_write_word(0x26, 0x0A)
+
+    for i in range(5):
+        yield
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(data, id_d):
+    yield tb.d[id_d].eq(0x00)
+    yield tb.page_pointer.eq(0x02)
+    yield tb.we.eq(0)
+    yield
+    yield tb.d[id_d].eq(data)
+    yield tb.we.eq(1)
+    yield
+    yield tb.d[id_d].eq(0x00)
+    yield tb.we.eq(0)
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")

--- a/litedram/DDR5RCD01/DDR5RCD01RegFile.py
+++ b/litedram/DDR5RCD01/DDR5RCD01RegFile.py
@@ -1,0 +1,206 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python
+from reprlib import *
+import logging
+# migen
+from migen import *
+from migen.fhdl import verilog
+# Litex
+from litedram.DDR5RCD01.RCD_definitions import *
+from litedram.DDR5RCD01.RCD_utils import *
+from litedram.DDR5RCD01.RCD_interfaces import *
+# Submodules
+from litedram.DDR5RCD01.DDR5RCD01Page import *
+
+
+class DDR5RCD01RegFile(Module):
+    """DDR5 RCD01 Register File
+    TODO Documentation
+      RCD Register File is used to model the:
+          - 96 direct addressable registers
+            Addressed 0-95
+          - Addresses 96-127 are bank pointers, combined with RW95
+      Features:
+        - On the CA line, a cmd will appear with an address write or read.
+        The address shall be decoded exactly as in the definition.
+        Even though all registers in the file shall be visible to the rest of the
+        model at all times (behavioral implementation), methods to
+         - read at a specific address
+         - write at a specific address
+        must be provided to implement the DDR5 Commands.
+      Block inputs:
+       clk, 'Core clock'
+       rst, 'Core reset'
+       addr, 'Address of the register You wish to modify'
+       we, 'Write enable to the register selected with addr'
+       d, '8 bit data to be written into the register'
+       registers,'all registers at all times are visible as output (unlikely to be synthesized at high-speed)'
+       q, 'addr point to some register. q shows its content'
+    """
+
+    def pretty_print_regs(self):
+        repack = Repr()
+        repack.maxstring = 20
+        line = '-'*80
+        logging.debug(line)
+        logging.debug('Register Space')
+        logging.debug(line+'0x00')
+        logging.debug("Signal "+"value "+"name "+"address " +
+                      "description "+"global "+"attribute ")
+        for id, meta in enumerate(self.registers_metadata):
+            reg = self.registers[id]
+            str_format = repack.repr(str(reg))+' | '
+            reg_val = (yield reg)
+            str_format = str_format + str(reg_val)+' | '
+            for m in meta:
+                # TODO Fix the global flag print
+                str_format = str_format + repack.repr(str(m)) + ' | '
+            logging.debug(str_format)
+            # TODO Fix
+            # This if-statement is here to prevent very long prints
+            # Repr can be used to limit the list output
+            if id == 5:
+                break
+        logging.debug(line+'0x05')
+
+    def load_rcd_definitions(self):
+        # self.rcw = RegisterControlWords()
+        self.registers_metadata = []
+        for id, decode_msg in enumerate(CONTROL_WORD_DECODING):
+            decode_msg.append(ControlWordAttributes.RD_WR)
+            self.registers_metadata.append(decode_msg)
+        # TODO Add tables for page meaning
+        # Currently only DA Regs
+
+    def __init__(self, d, addr, we, q, page):
+        # Register file
+        self.registers = Array(Signal(CW_REG_BIT_SIZE)
+                               for y in range(CW_DA_REGS_NUM+CW_PAGE_PTRS_NUM))
+        logging.debug('Created Register File: %d x %db', len(
+            self.registers), len(self.registers[0]))
+
+        # Attribute registers
+        attr_regs = AttributeRegs()
+        self.submodules.attr_regs = attr_regs
+
+        # Create da_regs_metadata
+        self.load_rcd_definitions()
+        # Initialize
+        #
+
+        # Translate the address
+
+        self.trans_addr = Signal()
+        # Registers
+        # 1. Read_only is set via attr_regs
+        # 2. Single cycle we to enable a write
+        # 3. Directly addressable
+        # If in channel A, set channel A to 1; then read_only must be anded with channel X bit
+        # TODO Re-enable address translation
+        # This line is not recommended for synthesis, produces a huge mux
+        for id in range(CW_DA_REGS_NUM):
+            self.sync += If(we == 1,
+                            If(addr == id,
+                               # read_only is 2, need to replace this
+                               If(self.attr_regs.attr_regs[id][2] == 0,
+                                  self.registers[id].eq(d))
+                               )
+                            )
+
+        for id in range(CW_DA_REGS_NUM, CW_DA_REGS_NUM+CW_PAGE_PTRS_NUM):
+            logging.debug("Register num = " + str(id) +
+                          " Page reg num=" + str(id-CW_DA_REGS_NUM))
+            self.comb += self.registers[id].eq(
+                page[id-CW_DA_REGS_NUM])
+
+        self.comb += q.eq(self.registers[self.registers[ADDR_CW_READ_POINTER]])
+
+
+class TestBed(Module):
+    def __init__(self):
+        #
+        self.we = Signal()
+        self.d = Signal(8)
+        self.addr = Signal(8)
+        self.q = Signal(CW_REG_BIT_SIZE)
+
+        self.page_we = Signal()
+        self.page_addr = Signal(8)
+        self.page_d = Signal(8)
+        self.page = DDR5RCD01Page(
+            addr=self.page_addr, we=self.page_we, d=self.page_d)
+        self.submodules += self.page
+        ###
+        self.submodules.dut = DDR5RCD01RegFile(
+            addr=self.addr, we=self.we, d=self.d, q=self.q, page=self.page)
+        # print(verilog.convert(self.dut))
+
+
+def run_test(tb):
+    logging.debug('Write test')
+    yield from tb.dut.pretty_print_regs()
+    yield from behav_write_word(0x04, 0x01)
+
+    yield from behav_write_page(0x0A, 0x04)
+    yield from behav_write_word(ADDR_CW_READ_POINTER, ADDR_CW_PAGE+0x0A)
+    yield from behav_write_page(0x0B, 0x03)
+    yield from behav_write_word(ADDR_CW_READ_POINTER, ADDR_CW_PAGE+0x0B)
+    yield from behav_write_page(0x0C, 0x02)
+    yield from behav_write_word(ADDR_CW_READ_POINTER, ADDR_CW_PAGE+0x0C)
+    yield from behav_iter_addr(0x00)
+
+    for i in range(5):
+        yield
+    logging.debug('Yield from write test.')
+
+
+def behav_write_word(addr, data):
+    yield tb.d.eq(0x00)
+    yield tb.we.eq(0)
+    yield tb.addr.eq(0x00)
+    yield
+    yield tb.d.eq(data)
+    yield tb.we.eq(1)
+    yield tb.addr.eq(addr)
+    yield
+    yield tb.d.eq(0x00)
+    yield tb.we.eq(0)
+    yield tb.addr.eq(0x00)
+    yield
+
+
+def behav_write_page(addr, data):
+    yield tb.page_d.eq(0x00)
+    yield tb.page_we.eq(0)
+    yield tb.page_addr.eq(0x00)
+    yield
+    yield tb.page_d.eq(data)
+    yield tb.page_we.eq(1)
+    yield tb.page_addr.eq(addr)
+    yield
+    yield tb.page_d.eq(0x00)
+    yield tb.page_we.eq(0)
+    yield tb.page_addr.eq(0x00)
+    yield
+
+
+def behav_iter_addr(addr):
+    for i in range(3):
+        yield tb.addr.eq(addr+i)
+        yield
+
+
+if __name__ == "__main__":
+    eT = EngTest()
+    logging.info("<- Module called")
+    raise NotImplementedError("Test of this block is to be done.")
+    tb = TestBed()
+    logging.info("<- Module ready")
+    run_simulation(tb, run_test(tb), vcd_name=eT.wave_file_name)
+    logging.info("<- Simulation done")
+    logging.info(str(eT))

--- a/litedram/DDR5RCD01/DDR5RCD01Shell.py
+++ b/litedram/DDR5RCD01/DDR5RCD01Shell.py
@@ -1,0 +1,139 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# RCD
+from litedram.DDR5RCD01.DDR5RCD01BCOMSimulationPads import DDR5RCD01BCOMSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01CoreEgressSimulationPads import  DDR5RCD01CoreEgressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01CoreIngressSimulationPads import  DDR5RCD01CoreIngressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01SidebandSimulationPads import  DDR5RCD01SidebandSimulationPads
+
+class DDR5RCD01Shell(Module):
+    """The DDR5RCD01Shell
+        is a module, which:
+          - implements the pin-out exactly as the DDR5RCD01_model
+          - connect relevant outputs to inputs. This provides a complete
+            pass-through (or bypass) performance.
+          - the purpose of this block is to quickly develop testbenches
+    """
+    def __init__(self, pads_ingress, pads_sideband, \
+                is_dual_channel=False, **kwargs):
+
+      self.submodules.pads_sideband = pads_sideband
+      self.submodules.pads_ingress = pads_ingress
+
+      pads_egress = DDR5RCD01CoreEgressSimulationPads(dcs_n_w=2, dca_w=14, is_dual_channel=is_dual_channel)
+      self.submodules.pads_egress = pads_egress
+
+      pads_bcom = DDR5RCD01BCOMSimulationPads(is_dual_channel=is_dual_channel)
+      self.submodules.pads_bcom = pads_bcom
+
+      # Note, dpar is not on the list, must be handled in RCD
+      # TODO handler dpar[b:a]
+      # Reset output
+
+      # Single channel connection matrix
+      # Signals in keys are dual channel
+      # Signals in values are single channel
+
+      # Order 'Forward' will result in a connection
+      # self.comb += egress.eq(ingress)
+      # Order 'Reverse' will result in a connection
+      # self.comb += ingress.eq(egress)
+
+      connection_matrix_sc ={
+      'dlbd' : ['qlbd','Reverse'],
+      'dlbs' : ['qlbs','Reverse'],
+      'qrst_n' : ['drst_n','Forward'],
+      # Clock outputs
+      # Rank 0, Row Top
+      'qack_t' :  ['dck_t','Forward'],
+      'qack_c' :  ['dck_c','Forward'],
+      # Rank 1, Row Top
+      'qbck_t' :  ['dck_t','Forward'],
+      'qbck_c' :  ['dck_c','Forward'],
+      # Rank 0, Row Bottom
+      'qcck_t' :  ['dck_t','Forward'],
+      'qcck_c' :  ['dck_c','Forward'],
+      # Rank 1, Row Top
+      'qdck_t' :  ['dck_t','Forward'],
+      'qdck_c' : ['dck_c','Forward'],
+      # Error
+      'derror_in_n' : ['alert_n', 'Reverse'],
+      }
+      
+      # Dual-channel connection matrix
+      # Signals in keys AND values are dual-channel
+      connection_matrix_dc ={
+      # Adress, Chip Select
+      # Top Row
+      'qacs_a_n' : ['dcs_n','Forward'],
+      'qaca_a' :  ['dca_n','Forward'],
+      # Bottom Row
+      'qacs_b_n' :  ['dcs_n','Forward'],
+      'qaca_b' :  ['dca_n','Forward'],
+      }  
+      
+      # Connect matrix_sc
+      print('Connection Table SC: Signal is connected to Signal ')
+
+      prefixes = [""] if not is_dual_channel else ["A_", "B_"]
+      for prefix in prefixes:
+          for key in connection_matrix_sc:
+            sig_eg = prefix+key
+            sig_in = connection_matrix_sc[key][0]
+            # Get attr in egress
+            atr_eg = getattr(self.pads_egress, sig_eg)
+            # Get attr in ingress
+            atr_in = getattr(self.pads_ingress, sig_in)
+            # Determine correct direction
+            direction = connection_matrix_sc[key][1]
+            if direction == 'Forward':
+              print('Connect : ' + sig_in + ' to ' + sig_eg)
+              self.comb += atr_eg.eq(atr_in)
+              pass
+            elif direction == 'Reverse':
+              print('Connect : ' + sig_eg + ' to ' + sig_in)
+              self.comb += atr_in.eq(atr_eg)
+              pass
+            else:
+                raise('Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+            # breakpoint()
+      
+      # TODO the only difference between the two loops is the added prefix, this could be joined
+
+      # Connect matrix dc
+      print('Connection Table DC: Signal is connected to Signal ')
+      for prefix in prefixes:
+          for key in connection_matrix_dc:
+            sig_eg = prefix+key
+            sig_in = prefix+connection_matrix_dc[key][0]
+            # Get attr in egress
+            atr_eg = getattr(self.pads_egress, sig_eg)
+            # Get attr in ingress
+            atr_in = getattr(self.pads_ingress, sig_in)
+            # Determine correct direction
+            direction = connection_matrix_dc[key][1]
+            if direction == 'Forward':
+              print('Connect : ' + sig_in + ' to ' + sig_eg)
+              self.comb += atr_eg.eq(atr_in)
+              pass
+            elif direction == 'Reverse':
+              print('Connect : ' + sig_eg + ' to ' + sig_in)
+              print(direction)
+              self.comb += atr_in.eq(atr_eg)
+              pass
+            else:
+                raise('Unsupported option defined in connection matrix. Supported: Forward, Reverse')
+            # breakpoint()
+
+if __name__ == "__main__":
+  raise NotImplementedError("Test of this block is to be done.")
+  pi = DDR5RCD01CoreIngressSimulationPads()
+  ps = DDR5RCD01SidebandSimulationPads()
+  objTB = DDR5RCD01Shell(pi,ps)
+  

--- a/litedram/DDR5RCD01/DDR5RCD01SidebandSimulationPads.py
+++ b/litedram/DDR5RCD01/DDR5RCD01SidebandSimulationPads.py
@@ -1,0 +1,28 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM
+from litedram.phy.sim_utils import SimPad, SimulationPads
+
+
+class DDR5RCD01SidebandSimulationPads(SimulationPads):
+    """ DDR5 RCD01 Sideband SimulationPads
+    TODO Documentation
+    TODO layout parameters fix
+    """
+
+    def layout(self):
+        sideband = [
+            SimPad('sda', 1),
+            SimPad('scl', 1),
+        ]
+        return sideband
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/DDR5RCD01System.py
+++ b/litedram/DDR5RCD01/DDR5RCD01System.py
@@ -1,0 +1,71 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM : RCD
+from litedram.DDR5RCD01.DDR5RCD01Chip import DDR5RCD01Chip
+from litedram.DDR5RCD01.DDR5RCD01DataBuffer import DDR5RCD01DataBuffer
+from litedram.DDR5RCD01.DDR5RCD01CoreIngressSimulationPads import  DDR5RCD01CoreIngressSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01SidebandSimulationPads import  DDR5RCD01SidebandSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01DataBufferSimulationPads import DDR5RCD01DataBufferSimulationPads
+from litedram.DDR5RCD01.DDR5RCD01Shell import DDR5RCD01Shell
+
+class DDR5RCD01System(Module):
+    """The DDR5 RCD01 System
+    
+    The DDR5 RCD01 System contains:
+    - the RCD chip
+    - the data buffer chips (LRDIMM and RDIMM)
+
+    1. RDIMM
+      - BCOM is unused
+      - Data buffer signals are passed through
+    2. LRDIMM [to be implemented]
+      - TODO enable BCOM support
+      - TODO attach a data buffer model
+
+    Implementation structure:
+    System:
+      -> RCD:
+        -> RCD Shell
+        -> RCD Chip
+          -> RCD Core
+      -> Data Buffers:
+        -> Data Buffer Shell
+        -> Data Buffer Chip
+    """
+    def __init__(self, pads_dram_data_ingress,\
+                       pads_sideband,\
+                       pads_rcd_ingress,\
+                       rcd_passthrough=True,\
+                       sideband_type='i2c',\
+                       aligned_reset_zero=False, dq_dqs_ratio=8, nranks=1, with_sub_channels=False, **kwargs):
+
+      self.submodules.pads_dram_data_ingress = pads_dram_data_ingress
+      self.submodules.pads_sideband = pads_sideband
+      self.submodules.pads_rcd_ingress = pads_rcd_ingress
+
+      # RCD
+      if rcd_passthrough:
+        RCD = DDR5RCD01Shell( pads_rcd_ingress, pads_sideband)
+      else:
+        RCD = DDR5RCD01Chip( pads_rcd_ingress, pads_sideband, sideband_type='i3c')
+      self.submodules.RCD = RCD
+      self.submodules.pads_egress = RCD.pads_egress
+
+      # Data Buffer
+      data_buffer = DDR5RCD01DataBuffer( pads_dram_data_ingress, dimm_type='RDIMM')
+      self.submodules.data_buffer = data_buffer
+      self.submodules.pads_dram_data_egress = data_buffer.pads_egress
+
+if __name__ == "__main__":
+  raise NotImplementedError("Test of this block is to be done.")
+  pi = DDR5RCD01CoreIngressSimulationPads()
+  ps = DDR5RCD01SidebandSimulationPads()
+  pdi = DDR5RCD01DataBufferSimulationPads()
+  objTB = DDR5RCD01System(pdi,ps,pi)
+  

--- a/litedram/DDR5RCD01/I2CSlave.py
+++ b/litedram/DDR5RCD01/I2CSlave.py
@@ -1,0 +1,27 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM : RCD
+from litedram.DDR5RCD01.DDR5RCD01SidebandSimulationPads import DDR5RCD01SidebandSimulationPads
+
+
+class I2CSlave(Module):
+    """ I2C Slave
+    TODO Documentation
+    """
+
+    def __init__(self, pads_sideband, **kwargs):
+        # TODO implementation
+        # When implementing change the Sideband Simulation Pads.
+        # This is only here to provide some connection.
+        sideband_2_core = DDR5RCD01SidebandSimulationPads()
+        self.submodules.sideband_2_core = sideband_2_core
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/I3CSlave.py
+++ b/litedram/DDR5RCD01/I3CSlave.py
@@ -1,0 +1,25 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# migen
+from migen import *
+# LiteDRAM : RCD
+from litedram.DDR5RCD01.DDR5RCD01SidebandSimulationPads import DDR5RCD01SidebandSimulationPads
+
+
+class I3CSlave(Module):
+    """ I3C Slave
+    TODO Documentation
+    """
+
+    def __init__(self, pads_sideband, **kwargs):
+        # TODO implementation
+        sideband_2_core = DDR5RCD01SidebandSimulationPads()
+        self.submodules.sideband_2_core = sideband_2_core
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/RCD_definitions.py
+++ b/litedram/DDR5RCD01/RCD_definitions.py
@@ -1,0 +1,341 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from enum import Enum
+from migen import *
+#
+TIE_LOW = 0
+TIE_HIGH = 1
+#
+# Directle addressed registers (DA Regs)
+# DA are 8 bit
+CW_REG_BIT_SIZE = 8
+# DA Addressing starts at 0
+CW_ADDR_DA_REGS_OFFSET = 0x00
+# There are 96 DA
+CW_DA_REGS_NUM = 96  # Directly addressable register count
+# 8-bit addressed pages
+CW_PAGE_ADDR_SIZE = 8
+# 32 page pointer
+# TODO Fix value, should be 32
+CW_PAGE_PTRS_NUM = 32
+# TODO Duplicate debug value of 1
+# CW_PAGE_SIZE = 1
+CW_ADDR_PAGE_PTRS_OFFSET = 0x60
+# 256 pages
+CW_PAGE_NUM = (2**CW_PAGE_ADDR_SIZE)
+# Total number of paged registers 8192
+CW_PAGE_REG_NUM = CW_PAGE_PTRS_NUM*CW_PAGE_NUM
+# All registers: 96+32+8192
+# CW_ALL_NUM = CW_DA_REGS_NUM+CW_PAGE_PTRS_NUM+CW_PAGE_REG_NUM
+CW_ALL_NUM = CW_DA_REGS_NUM+CW_PAGE_PTRS_NUM+CW_PAGE_REG_NUM
+
+ADDR_CW_READ_POINTER = 0x5E
+ADDR_CW_PAGE = 0x5F
+
+
+class ControlWordAttributes(Enum):
+    UNUSED_0 = 0
+    RESERVED = 1
+    READ_ONLY = 2
+    WRITE_ONLY = 3
+    RD_WR = 4
+    OTP = 5  # One Time Programmable
+    STICKY = 6  # Cleared by power cycle not Reset
+    # --Implementation specific
+    GLOBAL_ONLY = 7
+    IN_CHAN_A = 8
+    # If GLOBAL_ONLY AND IN_CHAN_A, then allow access
+    # else don't allow access (neither write nor read)
+
+
+class AttributeRegs(Module):
+    def __init__(self):
+        cwatr = ControlWordAttributes
+        bit_size = len(cwatr)
+        self.attr_regs = Array(Signal(CW_REG_BIT_SIZE)
+                               for y in range(CW_ALL_NUM))
+        glob_config_attr_regs = Array(
+            Constant(0b0001_0000, bits_sign=(8, 'signed')) for y in range(CW_ALL_NUM))
+        # TODO Assign the attributes based on specification
+        # Current implementation shall:
+        # - all registers are RD_WR, except:
+        # - register 0x02 shall be sticky
+        # - register 0x03 shall be read_only
+        #                          0b7654_3210 <- bit order as in ControlWordAttributes
+        # glob_config_attr_regs[2] = 0b0101_0000
+        # glob_config_attr_regs[3] = 0b0000_0100
+        for id, reg in enumerate(self.attr_regs):
+            self.comb += self.attr_regs[id].eq(glob_config_attr_regs[id])
+
+# Metadata
+    # Bits
+    # 7        6         5          4     3   2      1  0
+    # RESERVED READ_ONLY WRITE_ONLY RD_WR OTP STICKY NU NU
+    # NU - not used
+    # attr_reserved = 7
+    # attr_read_only = 6
+    # attr_write_only = 5
+    # attr_rd_wr = 4
+    # attr_otp = 3
+    # attr_sticky = 2
+    # self.metadata = [Array(Signal(8) for y in range(CW_ALL_NUM))]
+
+
+# Control Word Space
+#
+# -----------------------0x00
+# 96 directly addressed registers
+# -----------------------0x5F (95d)
+
+# -----------------------0x60 (96d)
+# 32 page pointer RW
+# -----------------------0x7F (127d)
+
+#
+# 256 Pages of 32 registers
+#
+
+
+# Table 88
+# Name, Address, Description, Global (Only Channel A)
+CONTROL_WORD_DECODING = [
+    ["RW00", 0x00, "Global Features", "Yes"],
+    ["RW01", 0x01, "Parity, CMD Blocking, and Alert", "Yes"],
+    ["RW02", 0x02, "Host Interface Training Mode", "Yes"],
+    ["RW03", 0x03, "DRAM & DB Interface Training Mode", "Yes"],
+    ["RW04", 0x04, "Command Space", "Yes"],
+    ["RW05", 0x05, "DIMM Operating Speed", "Yes"],
+    ["RW06", 0x06, "Fine Granularity DIMM Operating Speed", "Yes"],
+    ["RW07", 0x07, "Validation Pass-Through and Lockout Protection", "Yes"],
+    ["RW08", 0x08, "Clock Driver Enable", "No"],
+    ["RW09", 0x09, "Output Address and Control Enable", "No"],
+    ["RW0A", 0x0A, "QCK Signals Driver Characteristics", "No"],
+    ["RW0B", 0x0B, "Reserved", "No"],
+    ["RW0C", 0x0C, "QCA and QxCS_n Signals Characteristics", "No"],
+    ["RW0D", 0x0D, "Data Buffer Interface Driver Characteristics", "No"],
+    ["RW0E", 0x0E, "QCK, QCA and QCS Output Slew Rate", "No"],
+    ["RW0F", 0x0F, "BCK, BCOM and BCS Output Slew Rate", "No"],
+    ["RW10", 0x10, "IBT", "Yes"],
+    ["RW11", 0x11, "Command Latency Adder", "No"],
+    ["RW12", 0x12, "QACK Output Delay", "No"],
+    ["RW13", 0x13, "QBCK Output Delay", "No"],
+    ["RW14", 0x14, "QCCK Output Delay Control", "No"],
+    ["RW15", 0x15, "QDCK Output Delay Control", "No"],
+    ["RW16", 0x16, "Reserved", "No"],
+    ["RW17", 0x17, "QACS0 Output Delay", "No"],
+    ["RW18", 0x18, "QACS1 Output Delay", "No"],
+    ["RW19", 0x19, "QBCS0 Output Delay", "No"],
+    ["RW1A", 0x1A, "QBCS1 Output Delay", "No"],
+    ["RW1B", 0x1B, "QACA Output Delay", "No"],
+    ["RW1C", 0x1C, "QBCA Output Delay", "No"],
+    ["RW1D", 0x1D, "BCS and BCOM Output Delay", "No"],
+    ["RW1E", 0x1E, "BCK Output Delay", "No"],
+    ["RW1F", 0x1F, "Reserved", "No"],
+    ["RW20", 0x20, "Error Log Register", "No"],
+    ["RW21", 0x21, "Error Log Register", "No"],
+    ["RW22", 0x22, "Error Log Register", "No"],
+    ["RW23", 0x23, "Error Log Register", "No"],
+    ["RW24", 0x24, "Error Log Register", "No"],
+    ["RW25", 0x25, "SidebandBus", "Yes"],
+    ["RW26", 0x26, "Loopback", "Yes"],
+    ["RW27", 0x27, "Loop-back I/O", "Yes"],
+    ["RW28", 0x28, "I2C & I3C Basic Error Status", "Yes"],
+    ["RW29", 0x29, "I2C & I3C Basic Clear Error Status", "Yes"],
+    ["RW2A", 0x2A, "Vendor Specific", "Yes"],
+    ["RW2B", 0x2B, "Reserved", "No"],
+    ["RW2C", 0x2C, "Reserved", "No"],
+    ["RW2D", 0x2D, "Reserved", "No"],
+    ["RW2E", 0x2E, "Reserved", "No"],
+    ["RW2F", 0x2F, "Reserved", "No"],
+    ["RW30", 0x30, "DFE_Vref Range Limit", "Yes"],
+    ["RW31", 0x31, "DFE Configuration", "No"],
+    ["RW32", 0x32, "DPAR and DCA[6:0] DFE Training Mode", "No"],
+    ["RW33", 0x33, "Additional Filtering for DFE Training Mode", "No"],
+    ["RW34", 0x34, "LFSR DFE Training Mode", "No"],
+    ["RW35", 0x35, "LFSR State for DFE Training Mode", "No"],
+    ["RW36", 0x36, "DFETM Inner Loop Start Value", "No"],
+    ["RW37", 0x37, "DFETM Outer Loop Start Value", "No"],
+    ["RW38", 0x38, "DFETM Inner Loop Current Value", "No"],
+    ["RW39", 0x39, "DFETM Outer Loop Current Value", "No"],
+    ["RW3A", 0x3A, "DFETM Inner and Outer Loop Step Size", "No"],
+    ["RW3B", 0x3B, "DFETM Inner Loop Number of Increments", "No"],
+    ["RW3C", 0x3C, "DFETM Outer Loop Number of Increments", "No"],
+    ["RW3D", 0x3D, "DFETM Inner Loop Current Increment", "No"],
+    ["RW3E", 0x3E, "DFETM Outer Loop Current Increment", "No"],
+    ["RW3F", 0x3F, "DFE Vref Range Selection", "No"],
+    ["RW40", 0x40, "DCA0 Internal Vref", "No"],
+    ["RW41", 0x41, "DCA1 Internal Vref", "No"],
+    ["RW42", 0x42, "DCA2 Internal Vref", "No"],
+    ["RW43", 0x43, "DCA3 Internal Vref", "No"],
+    ["RW44", 0x44, "DCA4 Internal Vref", "No"],
+    ["RW45", 0x45, "DCA5 Internal Vref", "No"],
+    ["RW46", 0x46, "DCA6 Internal Vref", "No"],
+    ["RW47", 0x47, "DPAR Internal Vref", "No"],
+    ["RW48", 0x48, "DCS0 Internal Vref", "No"],
+    ["RW49", 0x49, "DCS1 Internal Vref", "No"],
+    ["RW4A", 0x4A, "DERROR_IN_n Vref", "No"],
+    ["RW4B", 0x4B, "Loop-Back Vref", "No"],
+    ["RW4C", 0x4C, "Reserved", "No"],
+    ["RW4D", 0x4D, "Reserved", "No"],
+    ["RW4E", 0x4E, "Reserved", "No"],
+    ["RW4F", 0x4F, "Reserved", "No"],
+    ["RW50", 0x50, "Reserved", "No"],
+    ["RW51", 0x51, "Reserved", "No"],
+    ["RW52", 0x52, "Reserved", "No"],
+    ["RW53", 0x53, "Reserved", "No"],
+    ["RW54", 0x54, "Reserved", "No"],
+    ["RW55", 0x55, "Reserved", "No"],
+    ["RW56", 0x56, "Reserved", "No"],
+    ["RW57", 0x57, "Reserved", "No"],
+    ["RW58", 0x58, "Reserved", "No"],
+    ["RW59", 0x59, "Reserved", "No"],
+    ["RW5A", 0x5A, "Reserved", "No"],
+    ["RW5B", 0x5B, "Reserved", "No"],
+    ["RW5C", 0x5C, "Reserved", "No"],
+    ["RW5D", 0x5D, "Reserved", "No"],
+    ["RW5E", 0x5E, "CW Read Pointer", "No"],
+    ["RW5F", 0x5F, "CW Page", "No"],
+]
+
+
+# Name, Address, Bits selector
+sticky_bits = [
+    ["RW00", 0x00, "[1:0]"],
+    ["RW05", 0x05, "[3:0]"],
+    ["RW05", 0x05, "[6:5]"],
+    ["RW06", 0x06, "[7:0]"],
+    ["RW08", 0x08, "[7:0]"],
+    ["RW09", 0x09, "[7:0]"],
+    ["RW0A", 0x0A, "[7:0]"],
+    ["RW0C", 0x0C, "[7:0]"],
+    ["RW0D", 0x0D, "[7:0]"],
+    ["RW0E", 0x0E, "[7:0]"],
+    ["RW0F", 0x0F, "[7:0]"],
+    ["RW10", 0x10, "[7:0]"],
+    ["RW11", 0x11, "[7:0]"],
+    ["RW12", 0x12, "[7:0]"],
+    ["RW13", 0x13, "[7:0]"],
+    ["RW14", 0x14, "[7:0]"],
+    ["RW15", 0x15, "[7:0]"],
+    ["RW17", 0x17, "[7:0]"],
+    ["RW18", 0x18, "[7:0]"],
+    ["RW19", 0x19, "[7:0]"],
+    ["RW1A", 0x1A, "[7:0]"],
+    ["RW1B", 0x1B, "[7:0]"],
+    ["RW1C", 0x1C, "[7:0]"],
+    ["RW1D", 0x1D, "[7:0]"],
+    ["RW1E", 0x1E, "[7:0]"],
+    ["RW25", 0x25, "[5]"],
+    ["RW28", 0x28, "[7:0]"],
+    ["RW31", 0x31, "[7:0]"],
+    ["RW40", 0x40, "[7:0]"],
+    ["RW41", 0x41, "[7:0]"],
+    ["RW42", 0x42, "[7:0]"],
+    ["RW43", 0x43, "[7:0]"],
+    ["RW44", 0x44, "[7:0]"],
+    ["RW45", 0x45, "[7:0]"],
+    ["RW46", 0x46, "[7:0]"],
+    ["RW47", 0x47, "[7:0]"],
+    ["RW48", 0x48, "[7:0]"],
+    ["RW49", 0x49, "[7:0]"],
+]
+
+sticky_pages = [
+    ["PG[1]RW", [1], [0x61, 0x69, 0x71, 0x79],
+        "DPAR and DCA[6:0] Receiver DFE Tap 1 Coefficients"],
+    ["PG[0]RW", [0], [0x61, 0x69, 0x71, 0x79],
+        "DPAR and DCA[6:0] Receiver DFE Tap 1 Coefficients"],
+    ["PG[1]RW", [1], [0x62, 0x6A, 0x72, 0x7A],
+        "DPAR and DCA[6:0] Receiver DFE Tap 2 Coefficients"],
+    ["PG[0]RW", [0], [0x62, 0x6A, 0x72, 0x7A],
+        "DPAR and DCA[6:0] Receiver DFE Tap 2 Coefficients"],
+    ["PG[1]RW", [1], [0x63, 0x6B, 0x73, 0x7B],
+        "DPAR and DCA[6:0] Receiver DFE Tap 3 Coefficients"],
+    ["PG[0]RW", [0], [0x63, 0x6B, 0x73, 0x7B],
+        "DPAR and DCA[6:0] Receiver DFE Tap 3 Coefficients"],
+    ["PG[1]RW", [1], [0x64, 0x6C, 0x74, 0x7C],
+        "DPAR and DCA[6:0] Receiver DFE Tap 4 Coefficients"],
+    ["PG[0]RW", [0], [0x64, 0x6C, 0x74, 0x7C],
+        "DPAR and DCA[6:0] Receiver DFE Tap 4 Coefficients"],
+    ["PG[1]RW", [1], [0x60, 0x68, 0x70, 0x78],
+        "DPAR and DCA[6:0] Receiver DFE Gain Offset Adjustment"],
+    ["PG[0]RW", [0], [0x60, 0x68, 0x70, 0x78],
+        "DPAR and DCA[6:0] Receiver DFE Gain Offset Adjustment"],
+]
+
+rcd_pages = {
+    "rcd_generic": [
+        ["RW60", 0x60, "not implemented"],
+        ["RW61", 0x61, "not implemented"],
+        ["RW62", 0x62, "not implemented"],
+        ["RW63", 0x63, "not implemented"],
+        ["RW64", 0x64, "not implemented"],
+        ["RW65", 0x65, "not implemented"],
+        ["RW66", 0x66, "not implemented"],
+        ["RW67", 0x67, "not implemented"],
+        ["RW68", 0x68, "not implemented"],
+        ["RW69", 0x69, "not implemented"],
+        ["RW6A", 0x6A, "not implemented"],
+        ["RW6B", 0x6B, "not implemented"],
+        ["RW6C", 0x6C, "not implemented"],
+        ["RW6D", 0x6D, "not implemented"],
+        ["RW6E", 0x6E, "not implemented"],
+        ["RW6F", 0x6F, "not implemented"],
+        ["RW70", 0x70, "not implemented"],
+        ["RW71", 0x71, "not implemented"],
+        ["RW72", 0x72, "not implemented"],
+        ["RW73", 0x73, "not implemented"],
+        ["RW74", 0x74, "not implemented"],
+        ["RW75", 0x75, "not implemented"],
+        ["RW76", 0x76, "not implemented"],
+        ["RW77", 0x77, "not implemented"],
+        ["RW78", 0x78, "not implemented"],
+        ["RW79", 0x79, "not implemented"],
+        ["RW7A", 0x7A, "not implemented"],
+        ["RW7B", 0x7B, "not implemented"],
+        ["RW7C", 0x7C, "not implemented"],
+        ["RW7D", 0x7D, "not implemented"],
+        ["RW7E", 0x7E, "not implemented"],
+        ["RW7F", 0x7F, "not implemented"],],
+    "rcd_page_0": [
+        ["RW60", 0x60, "DCA0 Rx DFE Gain Coefficients"],
+        ["RW61", 0x61, "DCA0 Rx DFE Tap 1 Coefficients"],
+        ["RW62", 0x62, "DCA0 Rx DFE Tap 2 Coefficients"],
+        ["RW63", 0x63, "DCA0 Rx DFE Tap 3 Coefficients"],
+        ["RW64", 0x64, "DCA0 Rx DFE Tap 4 Coefficients"],
+        ["RW65", 0x65, "RFU   "],
+        ["RW66", 0x66, "RFU   "],
+        ["RW67", 0x67, "RFU   "],
+        ["RW68", 0x68, "DCA1 Rx DFE Gain Coefficients"],
+        ["RW69", 0x69, "DCA1 Rx DFE Tap 1 Coefficients"],
+        ["RW6A", 0x6A, "DCA1 Rx DFE Tap 2 Coefficients"],
+        ["RW6B", 0x6B, "DCA1 Rx DFE Tap 3 Coefficients"],
+        ["RW6C", 0x6C, "DCA1 Rx DFE Tap 4 Coefficients"],
+        ["RW6D", 0x6D, "RFU   "],
+        ["RW6E", 0x6E, "RFU   "],
+        ["RW6F", 0x6F, "RFU   "],
+        ["RW70", 0x70, "DCA2 Rx DFE Gain Coefficients"],
+        ["RW71", 0x71, "DCA2 Rx DFE Tap 1 Coefficients"],
+        ["RW72", 0x72, "DCA2 Rx DFE Tap 2 Coefficients"],
+        ["RW73", 0x73, "DCA2 Rx DFE Tap 3 Coefficients"],
+        ["RW74", 0x74, "DCA2 Rx DFE Tap 4 Coefficients"],
+        ["RW75", 0x75, "RFU   "],
+        ["RW76", 0x76, "RFU   "],
+        ["RW77", 0x77, "RFU   "],
+        ["RW78", 0x78, "DCA3 Rx DFE Gain Coefficients"],
+        ["RW79", 0x79, "DCA3 Rx DFE Tap 1 Coefficients"],
+        ["RW7A", 0x7A, "DCA3 Rx DFE Tap 2 Coefficients"],
+        ["RW7B", 0x7B, "DCA3 Rx DFE Tap 3 Coefficients"],
+        ["RW7C", 0x7C, "DCA3 Rx DFE Tap 4 Coefficients"],
+        ["RW7D", 0x7D, "RFU   "],
+        ["RW7E", 0x7E, "RFU   "],
+        ["RW7F", 0x7F, "RFU   "],]
+}
+
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/RCD_interfaces.py
+++ b/litedram/DDR5RCD01/RCD_interfaces.py
@@ -1,0 +1,383 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+# if_<name> := Interface name
+# if_<name>_<block><function>
+
+
+class If_channel_ibuf(Record):
+    """
+    This interface is used for the following connections:
+    Core input of input buffer
+    Output of the input buffer
+    Input of the line buffer
+    Input of the Control Center
+    """
+
+    def __init__(self, dcs_n_w=2, dca_w=7):
+        layout = self.description(dcs_n_w, dca_w)
+        Record.__init__(self, layout)
+
+    def description(self, dcs_n_w, dca_w):
+        return [
+            ('dcs_n', dcs_n_w),
+            ('dca', dca_w),
+            ('dpar', 1),
+        ]
+
+
+class If_channel_obuf_clks(Record):
+    """
+    Q[D:A]CK_[T,C] Clock Bus
+    This interface is used for the following connections:
+    Input of the output buffer
+    Output of the line buffer
+    Core output of output buffer
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            # Clock outputs
+            # Rank 0, Row Top
+            ('qack_t', 1, False),
+            ('qack_c', 1, False),
+            # Rank 1, Row Top
+            ('qbck_t', 1, False),
+            ('qbck_c', 1, False),
+            # Rank 0, Row Bottom
+            ('qcck_t', 1, False),
+            ('qcck_c', 1, False),
+            # Rank 1, Row Top
+            ('qdck_t', 1, False),
+            ('qdck_c', 1, False),
+        ]
+
+
+class If_channel_obuf_csca(Record):
+    """
+    This interface is used for the following connections:
+    Input of the output buffer
+    Output of the line buffer
+    Core output of output buffer
+    """
+
+    def __init__(self, qacs_w=2, qaca_w=14):
+        layout = self.description(qacs_w, qaca_w)
+        Record.__init__(self, layout)
+
+    def description(self, qacs_w, qaca_w):
+        return [
+            # Adress, Chip Select
+            # Top Row
+            ('qacs_a_n', qacs_w, False),
+            ('qaca_a', qaca_w, False),
+            # Bottom Row
+            ('qacs_b_n', qacs_w, False),
+            ('qaca_b', qaca_w, False),
+        ]
+
+
+class If_channel_sdram(Record):
+    """
+    This interface is used for the:
+    Signals coming from the sdram to channel
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            # SDRAM raises an error
+            ('derror_in_n', 1, False),
+        ]
+
+
+class If_ctrl_ibuf(Record):
+    """
+    This interface is used for the:
+    Configuration of the input buffer
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('en', 1),
+        ]
+
+
+class If_ctrl_lbuf(Record):
+    """
+    This interface is used for the:
+    Configuration of the line buffer
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('sel_latency_add', 3),
+            ('deser_sel_lower_upper', 1),
+            ('deser_ca_d_en', 1),
+            ('deser_ca_q_en', 1),
+            ('deser_cs_n_d_en', 1),
+            ('deser_cs_n_q_en', 1),
+
+        ]
+
+
+class If_ctrl_obuf(Record):
+    """
+    This interface is used for the:
+    Configuration of the output buffer
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('oe_qacs_a_n', 1),
+            ('o_inv_en_qacs_a_n', 1),
+            ('oe_qaca_a', 1),
+            ('o_inv_en_qaca_a', 1),
+            ('oe_qacs_b_n', 1),
+            ('o_inv_en_qacs_b_n', 1),
+            ('oe_qaca_b', 1),
+            ('o_inv_en_qaca_b', 1),
+            ('oe_qack_t', 1),
+            ('o_inv_en_qack_t', 1),
+            ('oe_qack_c', 1),
+            ('o_inv_en_qack_c', 1),
+            ('oe_qbck_t', 1),
+            ('o_inv_en_qbck_t', 1),
+            ('oe_qbck_c', 1),
+            ('o_inv_en_qbck_c', 1),
+            ('oe_qcck_t', 1),
+            ('o_inv_en_qcck_t', 1),
+            ('oe_qcck_c', 1),
+            ('o_inv_en_qcck_c', 1),
+            ('oe_qdck_t', 1),
+            ('o_inv_en_qdck_t', 1),
+            ('oe_qdck_c', 1),
+            ('o_inv_en_qdck_c', 1)
+        ]
+
+
+class If_channel_config_global(Record):
+    """
+    This interface is used for the:
+    Configuration of the B channel global settings
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            # TODO list all RWs that are global, based on the global list in definitions.
+            ('Global_RWs', 1),
+        ]
+
+
+class If_channel_config_common(Record):
+    """
+    This interface is used for the:
+    Configuration of the common block settings
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            # TODO add RWs, e.g. PLL control, loopback mode, error mode
+            ('Common_RWs', 1),
+        ]
+
+
+class If_common_sdram(Record):
+    """
+    Channel/common signals
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('qrst_a_n', 1),
+            ('qrst_b_n', 1),
+        ]
+
+
+class If_channel_common(Record):
+    """
+    Channel/common signals
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('error', 1),
+            ('dlbd',  1),
+            ('dlbs',  1),
+        ]
+
+
+class If_lb(Record):
+    """
+    Host/RCD loopback interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('lbd',    1),
+            ('lbs',    1),
+        ]
+
+
+class If_int_lb(Record):
+    """
+    DFE Tap internal loopback interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('dca_lb',    7),
+            ('dpar_lb',    1),
+        ]
+
+
+class If_rst_n(Record):
+    """
+    Global reset
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def if_assert(self):
+        yield self.rst_n.eq(0)
+
+    def if_deassert(self):
+        yield self.rst_n.eq(1)
+
+    def description(self):
+        return [
+            ('rst_n',    1),
+        ]
+
+
+class If_error(Record):
+    """
+    Host/RCD error interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('err_n', 1),
+        ]
+
+
+class If_ck(Record):
+    """
+    Clock interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('ck_t', 1),
+            ('ck_c', 1),
+        ]
+
+
+class If_ctrl_pll(Record):
+    """
+    PLL configuration interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('en', 1),
+            ('bypass', 1),
+        ]
+
+
+class If_ctrl_lb(Record):
+    """
+    Loopback configuration interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('en', 1),
+            ('sel_mode', 1),
+            ('sel_phase_ab', 1),
+            ('sel_int_bit', 3),
+        ]
+
+
+class If_ctrl_err(Record):
+    """
+    Error configuration interface
+    """
+
+    def __init__(self):
+        layout = self.description()
+        Record.__init__(self, layout)
+
+    def description(self):
+        return [
+            ('en', 1),
+        ]
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/RCD_utils.py
+++ b/litedram/DDR5RCD01/RCD_utils.py
@@ -1,0 +1,47 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import logging
+import os
+import inspect
+
+
+class EngTest():
+    def __init__(self, level=logging.DEBUG):
+        # Setup
+        dir_name = "./test_eng"
+        if not os.path.exists(dir_name):
+            # Test eng dir does not exist
+            os.mkdir(dir_name)
+        # file_name = "input_buffer"
+        full_file_name = inspect.stack()[-1].filename
+        file_name = (full_file_name.split('/')[-1]).split('.')[0]
+        log_file_name = dir_name + '/' + file_name+".log"
+        wave_file_name = dir_name + '/' + file_name+".vcd"
+        log_level = level
+        # log_level = logging.INFO
+        log_handlers = [logging.FileHandler(
+            log_file_name), logging.StreamHandler()]
+        log_format = "[%(module)s.%(funcName)s] %(message)s"
+        logging.basicConfig(format=log_format,
+                            handlers=log_handlers, level=log_level)
+
+        self.dir_name = dir_name
+        self.file_name = file_name
+        self.full_file_name = full_file_name
+        self.log_file_name = log_file_name
+        self.wave_file_name = wave_file_name
+        self.log_handlers = log_handlers
+
+    def __str__(self):
+        description = "\n--Summary--\n"
+        description += "Called:\t" + self.file_name + "\n"
+        description += "Log:\t" + self.log_file_name + "\n"
+        description += "Wave:\t" + self.wave_file_name + "\n"
+        return description
+
+if __name__ == "__main__":
+    raise NotImplementedError("Test of this block is not provided.")

--- a/litedram/DDR5RCD01/README.md
+++ b/litedram/DDR5RCD01/README.md
@@ -1,0 +1,63 @@
+# LiteDRAM DDR5 RCD01 Simulation Model
+
+The model provides a simplified view of the RCD chip used
+on Registered Dual-Inline Memory Modules (RDIMM) for the DDR5 technology. The model is meant for simulation only. The model is
+validated with the migen simulator tool.
+
+## Table of contents
+* [This directory](#this-directory)
+* [Implementation](#the-implementation)
+* [TODO](#TODO)
+* [Setup](#setup)
+* [License](#license)
+
+
+## Scope
+    
+    1. implementation of the DDR5 RCD01 model
+    2. unit tests in 'unittests/'
+
+    3. integration tests in 'tests/'
+
+    4. run engineering tests with:
+        $> bash run.sh
+    Logs and waveform are produced in 'eng_test/' dir
+
+## The implementation
+    1. DDR5 RCD01 Core
+        - meant to meet the JESD82-511 specification
+        - top-level implementation of the RCD physical functions
+        - integrates DDR5RCD01xxx blocks (channel A, B and common part)
+        - RCD definitons, utils and interfaces contain configuration
+        information about the RCD Core (bus widths, register file size, etc.)
+    2. DDR5 RCD01 System is a wrapper to enable integration with
+    existing LiteDRAM implementations. The System encapsulates:
+        - RCD Chip
+            - Core
+            - IXC slaves
+        - Data Buffer Chip:
+            - Data Buffer
+    
+    Data Buffers are wrappers for possible future LRDIMM applications.
+    
+    Files *SimulationPads* are interfaces meant for litedram integration
+    
+    IXC slaves are empty wrapper meant as placeholders for possible implementation of the SMBus
+
+## Setup
+    - setup as in rowhammer
+
+## TODO
+        [x] Initial implementation
+        [ ] Full implementation
+        [x] Engineering tests
+        [ ] Unit tests
+        [ ] Integration test
+
+## License
+
+This file is part of LiteDRAM.
+
+Copyright (c) 2023 Antmicro <www.antmicro.com>
+
+SPDX-License-Identifier: BSD-2-Clause

--- a/litedram/DDR5RCD01/run.sh
+++ b/litedram/DDR5RCD01/run.sh
@@ -1,0 +1,57 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+#!/bin/bash
+
+# This script runs all engineering tests.
+# There are 3 possible outcomes:
+# 1. The test builds, prints a log file and a waveform file
+# 2. The test raises an error message "this test is to be done"
+#    This means that the test has a known bug or its implementation is unfinished.
+# 3. The test raises an error message "this test is not provided"
+#    This means that explicit testing of this module is not in the validation plan.
+
+all_py=( \
+    "DDR5GlueRCDData.py" \
+    "DDR5GlueRCD.py" \
+    "DDR5RCD01Alert.py" \
+    "DDR5RCD01BCOMSimulationPads.py" \
+    "DDR5RCD01Channel.py" \
+    "DDR5RCD01Chip.py" \
+    "DDR5RCD01Common.py" \
+    "DDR5RCD01ControlCenter.py" \
+    "DDR5RCD01CoreEgressSimulationPads.py" \
+    "DDR5RCD01CoreIngressSimulationPads.py" \
+    "DDR5RCD01Core.py" \
+    "DDR5RCD01DataBufferChip.py" \
+    "DDR5RCD01DataBuffer.py" \
+    "DDR5RCD01DataBufferShell.py" \
+    "DDR5RCD01DataBufferSimulationPads.py" \
+    "DDR5RCD01Error.py" \
+    "DDR5RCD01FetchDecode.py" \
+    "DDR5RCD01InputBuffer.py" \
+    "DDR5RCD01LineBuffer.py" \
+    "DDR5RCD01Loopback.py" \
+    "DDR5RCD01OutputBuffer.py" \
+    "DDR5RCD01Page.py" \
+    "DDR5RCD01Pages.py" \
+    "DDR5RCD01PLL.py" \
+    "DDR5RCD01RegFile.py" \
+    "DDR5RCD01Shell.py" \
+    "DDR5RCD01SidebandSimulationPads.py" \
+    "DDR5RCD01System.py" \
+    "I2CSlave.py" \
+    "I3CSlave.py" \
+    "RCD_definitions.py" \
+    "RCD_interfaces.py" \
+    "RCD_utils.py" \
+)
+
+for test in ${all_py[@]}; do
+    python $test
+    read -p 'Next test?' user_continue
+done
+

--- a/litedram/DDR5RCD01/tests/test_top.py
+++ b/litedram/DDR5RCD01/tests/test_top.py
@@ -1,0 +1,7 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Placeholder for the integration test

--- a/litedram/DDR5RCD01/unittests/test_core.py
+++ b/litedram/DDR5RCD01/unittests/test_core.py
@@ -1,0 +1,7 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Placeholder for the unit tests


### PR DESCRIPTION
This PR adds the initial version of the RCD model. A number of features
is implemented including, but not limited to:
- hierarchical structure, which facilitates future development,
- normal mode CA/CS bus buffering (known bug with output inversion on rank B). 

The buffered output is SDR - not all available modes (DDR, SDR1, SDR2) were tested. Relevant configuration registers for mode selection and block control are implemented, but the paging system is not operational. At this stage, the model can be simulated with migen (see run.sh).

Features that are partially implemented (not tested) include:
   - [ ] DDR commands decoding,
   - [ ] Mode change (CA validation, transparent, etc.)
   - [ ] Parity error host alert,
   - [ ] Loopback
   - [ ] unitests and litedram integration test
