### PR TITLE
Increase timeouts for lpddr4, lpddr5 and ddr5 verilator tests

### DIFF
--- a/test/test_ddr5.py
+++ b/test/test_ddr5.py
@@ -1202,7 +1202,7 @@ class VerilatorDDR5Tests(unittest.TestCase):
         import pexpect
 
         command = ["python3", simsoc.__file__, *args]
-        timeout = 120 * 60  # give more than enough time for CI
+        timeout = 3 * 60 * 60  # give more than enough time for CI
         p = pexpect.spawn(" ".join(command), timeout=timeout, **kwargs)
 
         res = p.expect(["Memtest OK", "Memtest KO"])

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -676,7 +676,7 @@ class VerilatorLPDDR4Tests(unittest.TestCase):
         import pexpect
 
         command = ["python3", simsoc.__file__, *args]
-        timeout = 12 * 60  # give more than enough time
+        timeout = 30 * 60  # give more than enough time
         p = pexpect.spawn(" ".join(command), timeout=timeout, **kwargs)
 
         res = p.expect(["Memtest OK", "Memtest KO"])

--- a/test/test_lpddr5.py
+++ b/test/test_lpddr5.py
@@ -731,7 +731,7 @@ class VerilatorLPDDR5Tests(unittest.TestCase):
         import pexpect
 
         command = ["python3", simsoc.__file__, *args]
-        timeout = 12 * 60  # give more than enough time
+        timeout = 30 * 60  # give more than enough time
         p = pexpect.spawn(" ".join(command), timeout=timeout, **kwargs)
 
         res = p.expect(["Memtest OK", "Memtest KO"])


### PR DESCRIPTION
Some CI runs go green and some CI runs get timeouts on these tests. I increased the timeout to 30 minutes per test,
as this should be well above current run time.

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>